### PR TITLE
Removed Footer icons

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,4 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import logg from './rdk.svg';
 import loggd from './rdkd.svg';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,11 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import logg from './rdk.svg';
 import loggd from './rdkd.svg';
-import { 
-  Github, 
-  Twitter, 
-  Linkedin, 
-  Mail, 
+import {  
   Heart,
   Home,
   Layers,
@@ -50,13 +46,6 @@ export default function Footer() {
       { name: 'Contact', href: '#' },
     ],
   };
-
-  const socialLinks = [
-    { name: 'GitHub', icon: Github, href: 'https://github.com/Mayur-Pagote/README_Design_Kit' },
-    { name: 'Twitter', icon: Twitter, href: '#' },
-    { name: 'LinkedIn', icon: Linkedin, href: '#' },
-    { name: 'Email', icon: Mail, href: 'mailto:contact@readmedesignkit.com' },
-  ];
 
   const handleLegalLinkClick = (path: string) => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -105,28 +94,6 @@ export default function Footer() {
               Create stunning README files with our comprehensive design toolkit. 
               Beautiful components, drag-and-drop editor, and endless possibilities for your documentation.
             </p>
-            
-            {/* Social Links */}
-            <div className="flex gap-3">
-              {socialLinks.map((social) => (
-                <Button
-                  key={social.name}
-                  variant="ghost"
-                  size="sm"
-                  className="h-9 w-9 p-0 transition-all hover:scale-110 focus:ring-2 focus:ring-primary focus:ring-offset-2"
-                  asChild
-                >
-                  <a
-                    href={social.href}
-                    target={social.href.startsWith('http') ? '_blank' : undefined}
-                    rel={social.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                    aria-label={social.name}
-                  >
-                    <social.icon className="h-4 w-4" />
-                  </a>
-                </Button>
-              ))}
-            </div>
           </div>
 
           {/* Navigation Links */}


### PR DESCRIPTION
# 🛠 Pull Request Template


## 📌 Related Issue


Fixes: #56   


## 🔍 Describe your changes?

Removed four social media icons from the footer: GitHub, Mail, LinkedIn, and Twitter, as requested in the issue.

Ensured the footer remains clean and aligned with the maintainers' intended design, as the GitHub link is already present in the navbar.


---


## 📸 Screenshot

![image](https://github.com/user-attachments/assets/d8fc2294-f8b9-4df9-96c4-d5fc938dd63c)


---


## 🧪 Checklist


Please check all that apply:


- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)
While exploring the additional request to make the GitHub star button trigger a direct repo star from the website, I found that:

GitHub’s API for starring a repo requires authentication via OAuth or a personal access token, which is not feasible or secure to implement directly in the frontend.

Embedding a GitHub “Star” button using an iframe or GitHub’s widget is possible, but it will redirect the user to GitHub to complete the action, not star it automatically.

Any attempt to star via API from the frontend would pose a security risk and go against GitHub's best practices.

Therefore, that feature would need backend logic and user auth — which may be too complex for this scope.



---


## Thank you for contributing!


---

