### PR TITLE
fix:Text selection blue colour while doing ctrl+A causes mess in the …

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -56,11 +56,34 @@ export default function Home() {
   animate={{ opacity: 1, y: 0 }} 
   transition={{ delay: 0.2, duration: 0.8 }} 
   className="flex flex-col items-center justify-center w-full max-w-4xl mx-auto"
->  <h1 className="text-center text-[52px] leading-none sm:text-[80px] lg:text-[70px] font-bold bg-gradient-to-r from-foreground via-primary to-primary bg-clip-text text-transparent">
-    <span>Create,</span>{" "}
-    Generate, and{" "}
-    <span className="text-primary drop-shadow-sm">Share</span> in Seconds!
-  </h1>
+>  <h1
+  className="
+    text-center text-[52px] leading-none sm:text-[80px] lg:text-[70px]
+    font-bold
+    bg-gradient-to-r from-foreground via-primary to-primary
+    bg-clip-text text-transparent
+    select-text
+    [&::selection]:bg-transparent
+    [&::selection]:text-current
+    [&_*::selection]:bg-transparent
+    [&_*::selection]:text-current
+  "
+>
+
+  <span className="inline-block bg-gradient-to-r from-foreground via-primary to-primary bg-clip-text text-transparent">
+    Create,
+  </span>{" "}
+  <span className="inline-block bg-gradient-to-r from-foreground via-primary to-primary bg-clip-text text-transparent">
+    Generate, and
+  </span>{" "}
+  <span className="inline-block text-primary drop-shadow-sm">
+    Share
+  </span>{" "}
+  <span className="inline-block bg-gradient-to-r from-foreground via-primary to-primary bg-clip-text text-transparent">
+    in Seconds!
+  </span>
+</h1>
+
 </motion.div>          <motion.h2
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
…homepage issue #283

 fix: Improve text selection visibility on homepage heading


Fixes: #283 

<h1
  className="
    text-center text-[52px] leading-none sm:text-[80px] lg:text-[70px]
    font-bold
    bg-gradient-to-r from-foreground via-primary to-primary
    bg-clip-text text-transparent
    select-text
    [&::selection]:bg-transparent
    [&::selection]:text-current
    [&_*::selection]:bg-transparent
    [&_*::selection]:text-current
  "
>




## 🔍 Describe your changes?
The main heading on the home page cannot be selected as text because if text selection is on, the blue text selection colour overlaps and causes mess to look at



## 📸 Screenshot


Using ctrl+a after the fix
<img width="1387" height="848" alt="image" src="https://github.com/user-attachments/assets/cb37716f-6d41-4697-a248-0bfd5850dd24" />





## 🧪 Checklist


Please check all that apply:


- [Yes] I have tested my changes locally.
- [Yes] I have followed the project's code style and guidelines.
- [Yes] I have added necessary comments and documentation.
- [Yes] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)




---


## Thank you for contributing!


---

