### PR TITLE
Enhancement: add Codeforces dark/light theme profile stats cards

### DIFF
--- a/src/data/componentsData.ts
+++ b/src/data/componentsData.ts
@@ -665,7 +665,7 @@ export const componentsData: Record<string, ComponentItem[]> = {
     },
     {
       title: "Codeforces Light Theme Profile Stats",
-      description: "Dispalys Codeforces Profile with Light theme",
+      description: "Dispalys Codeforces Profile with light theme",
       imageUrl:
         "https://codeforces-readme-stats.vercel.app/api/card?username=tourist&theme=default&disable_animations=false&show_icons=true&force_username=true",
       codeSnippet: `<img height="180em" src="https://codeforces-readme-stats.vercel.app/api/card?username={username}&theme=default&disable_animations=false&show_icons=true&force_username=true"/>`,


### PR DESCRIPTION
### **Summary**
This PR adds Codeforces profile stats cards with both dark and light theme options to the coding-platforms category.

### **Related Issue**
Closes  #321 

### **Changes Made**

1. Added Codeforces Dark Theme Profile Stats card with Dark theme
2. Added Codeforces Light Theme Profile Stats card with Light theme

### **Screenshots**
<img width="1198" height="870" alt="image" src="https://github.com/user-attachments/assets/fe1a2a8d-4e7f-47f5-8d84-aac895ddd916" />

### **Testing**
1. Ran the project locally
2. Verified both Codeforces theme cards render correctly in the UI
3. Confirmed code snippets generate valid markdown with {username} placeholder
4. Tested image URLs on markdown.live - renders as expected
5. No runtime or TypeScript errors observed
