### PR TITLE
Remove showcase section from navigation and routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ import Home from "./pages/Home";
 import Layout from "./components/Layout";
 import ScrollToTop from "./components/ScrollToTop";
 import Elements from "./pages/Elements";
-import Hero from "./pages/Hero";
+// import Hero from "./pages/Hero";
 import ProjectsSection from "./components/ProjectsSection";
 import SubmitSection from "./components/SubmitSection";
 import DragDropEditor from "./pages/DragDropEditor";
@@ -51,7 +51,7 @@ export default function App() {
               <Route path="/" element={<Layout><Home /></Layout>} />
               <Route path="/elements" element={<Layout><Elements /></Layout>} />
               <Route path="/templates" element={<Layout><TemplateLibraryPage /></Layout>} />
-              <Route path="/showcase" element={<Layout><Hero /></Layout>} />
+              {/* <Route path="/showcase" element={<Layout><Hero /></Layout>} /> */}
               <Route path="/projects" element={<Layout><ProjectsSection /></Layout>} />
               <Route path="/submit" element={<Layout><SubmitSection /></Layout>} />
               <Route path="/drag-drop" element={<Layout><DragDropEditor /></Layout>} />

--- a/src/components/_components/footer.tsx
+++ b/src/components/_components/footer.tsx
@@ -7,7 +7,7 @@ import logg from '../rdk.svg';
 const links = [
     { title: 'Templates', to: '/templates' },
     { title: 'Elements', to: '/elements' },
-    { title: 'Showcase', to: '/showcase' },
+    // { title: 'Showcase', to: '/showcase' },
     { title: 'Drag & Drop Editor', to: '/drag-drop' },
     { title: 'Readme Generator', to: '/readme-generator' },
     { title: 'Coming Soon', to: '/coming-soon' },
@@ -54,7 +54,7 @@ export default function Footer() {
                         <div className="flex flex-col space-y-4">
                             <h4 className="text-sm font-semibold text-foreground uppercase tracking-wider">Product</h4>
                             <ul className="flex flex-col space-y-2 text-sm">
-                                {links.slice(0, 3).map((link, idx) => (
+                                {links.slice(0, 2).map((link, idx) => (
                                     <li key={idx}>
                                         <Link to={link.to} className="text-muted-foreground hover:text-primary transition-colors duration-150">{link.title}</Link>
                                     </li>
@@ -67,7 +67,7 @@ export default function Footer() {
                         <div className="flex flex-col space-y-4">
                             <h4 className="text-sm font-semibold text-foreground uppercase tracking-wider">Tools</h4>
                             <ul className="flex flex-col space-y-2 text-sm">
-                                {links.slice(3).map((link, idx) => (
+                                {links.slice(2).map((link, idx) => (
                                     <li key={idx}>
                                         <Link to={link.to} className="text-muted-foreground hover:text-primary transition-colors duration-150">{link.title}</Link>
                                     </li>

--- a/src/components/_components/header.tsx
+++ b/src/components/_components/header.tsx
@@ -11,7 +11,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 
 const moreItems = [
     { name: 'Templates', to: '/templates' },
-    { name: 'Showcase', to: '/showcase' },
+    // { name: 'Showcase', to: '/showcase' },
     { name: 'Drag & Drop Editor', to: '/drag-drop' },
     { name: 'Readme Generator', to: '/readme-generator'},
     { name: 'Coming Soon', to: '/coming-soon' },


### PR DESCRIPTION
# 🛠 Pull Request Template


## 📌 Related Issue


Fixes: #344 


---




## 🔍 Describe your changes?

**Changes made:**
- Removed `/showcase` route from `App.tsx`
- Removed `Hero` component import from `App.tsx`
- Removed "Showcase" navigation link from `Header.tsx` dropdown menu
- Removed "Showcase" link from `Footer.tsx` navigation
- Adjusted Footer section splits to maintain proper categorization (Product vs Tools sections)



---


## 📸 Screenshot


<img width="1920" height="842" alt="image" src="https://github.com/user-attachments/assets/2af5c362-d679-40ba-bd0c-b96558bee20c" />


---


## 🧪 Checklist


Please check all that apply:


- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [ ] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)




---


## Thank you for contributing!


---

