### PR TITLE
Improve mobile viewports

### DIFF
--- a/src/components/EditorCanvas.tsx
+++ b/src/components/EditorCanvas.tsx
@@ -19,15 +19,18 @@ import { SimpleDraggableElement } from './SimpleDraggableElement';
 import { Card } from '@/components/ui/card';
 import { Plus } from 'lucide-react';
 import type { ElementType } from '@/types/elements';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 interface EditorCanvasProps {
   elements: ElementType[];
   onElementsChange: (elements: ElementType[]) => void;
   onEditElement: (element: ElementType) => void;
   viewMode?: 'developer' | 'recruiter' | 'client';
+  onReorderElement?: (elementId: string, direction: 'up' | 'down') => void;
 }
-export function EditorCanvas({ elements, onElementsChange, onEditElement, viewMode }: EditorCanvasProps) {
+export function EditorCanvas({ elements, onElementsChange, onEditElement, viewMode, onReorderElement }: EditorCanvasProps) {
   const [activeId, setActiveId] = useState<string | null>(null);
+  const isMobile = useIsMobile();
 
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -67,11 +70,13 @@ export function EditorCanvas({ elements, onElementsChange, onEditElement, viewMo
         <div className="mb-6">
           <h2 className="text-xl font-semibold mb-2">README Editor</h2>
           <p className="text-sm text-muted-foreground">
-            Drag and drop elements to reorder them. Click the edit button to customize each element.
+            {isMobile 
+              ? 'Use the arrow buttons to reorder elements. Tap buttons to edit or delete.'
+              : 'Drag and drop elements to reorder them. Click the edit button to customize each element.'}
           </p>
         </div>
         <DndContext
-          sensors={sensors}
+          sensors={isMobile ? [] : sensors}
           collisionDetection={closestCenter}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
@@ -83,12 +88,14 @@ export function EditorCanvas({ elements, onElementsChange, onEditElement, viewMo
             <div className="space-y-4">
               {elements.length === 0 ? (
                 <Card className="p-12 border-2 border-dashed border-border bg-background/50">
-                  <div className="text-center text-muted-foreground">
-                    <Plus className="h-12 w-12 mx-auto mb-4 opacity-50" />
+                  <div className="text-center text-muted-foreground flex flex-col items-center justify-center">
+                    <div className="flex items-center justify-center mb-4">
+                      <Plus className="h-12 w-12 opacity-50" />
+                    </div>
                     <h3 className="text-lg font-medium mb-2">Start Building Your README</h3>
                     <p className="text-sm max-w-md mx-auto mb-4">
                       Add elements from the sidebar to create your README.
-                      You can drag and drop to reorder them.
+                      {isMobile ? ' Use the arrow buttons to reorder them.' : ' You can drag and drop to reorder them.'}
                     </p>
                     <p className="text-xs text-muted-foreground">
                       💡 Try clicking "Load Demo" to see example content!
@@ -96,30 +103,38 @@ export function EditorCanvas({ elements, onElementsChange, onEditElement, viewMo
                   </div>
                 </Card>
               ) : (
-                elements.map(element => (
+                elements.map((element, index) => (
                   <SimpleDraggableElement
                     key={element.id}
                     element={element}
                     onEdit={onEditElement}
                     onDelete={handleDeleteElement}
                     viewMode={viewMode}
+                    isMobile={isMobile}
+                    onMoveUp={onReorderElement ? () => onReorderElement(element.id, 'up') : undefined}
+                    onMoveDown={onReorderElement ? () => onReorderElement(element.id, 'down') : undefined}
+                    canMoveUp={index > 0}
+                    canMoveDown={index < elements.length - 1}
                   />
                 ))
               )}
             </div>
           </SortableContext>
-          <DragOverlay>
-            {activeId ? (
-              <div className="opacity-75 rotate-1 scale-105">
-                <SimpleDraggableElement
-                  element={elements.find(el => el.id === activeId)!}
-                  onEdit={() => {}}
-                  onDelete={() => {}}
-                  viewMode={viewMode}
-                />
-              </div>
-            ) : null}
-          </DragOverlay>
+          {!isMobile && (
+            <DragOverlay className="flex items-center justify-center">
+              {activeId ? (
+                <div className="opacity-75 rotate-1 scale-105 mx-auto">
+                  <SimpleDraggableElement
+                    element={elements.find(el => el.id === activeId)!}
+                    onEdit={() => {}}
+                    onDelete={() => {}}
+                    viewMode={viewMode}
+                    isMobile={false}
+                  />
+                </div>
+              ) : null}
+            </DragOverlay>
+          )}
         </DndContext>
       </div>
     </div>

--- a/src/components/ElementPalette.tsx
+++ b/src/components/ElementPalette.tsx
@@ -13,6 +13,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useIsMobile } from '@/hooks/use-mobile';
 import { TechStackDialog } from './TechStackDialog';
 import type { ElementType } from '@/types/elements';
 
@@ -23,6 +24,7 @@ interface ElementPaletteProps {
 export function ElementPalette({ onAddElement }: ElementPaletteProps) {
   const [activeTab, setActiveTab] = useState("basic");
   const [showTechStackDialog, setShowTechStackDialog] = useState(false);
+  const isMobile = useIsMobile();
   
   // Basic element types
   const basicElementTypes: {
@@ -235,11 +237,11 @@ export function ElementPalette({ onAddElement }: ElementPaletteProps) {
 
   return (
     <TooltipProvider>
-      <div className="w-80 border-r border-border bg-muted/50 p-4 overflow-auto">
-        <div className="mb-4">
-          <h2 className="font-semibold text-lg mb-2">Element Palette</h2>
-          <p className="text-sm text-muted-foreground">
-            Drag elements to build your README
+      <div className="w-full md:w-80 border-r border-border bg-muted/50 p-3 md:p-4 overflow-auto">
+        <div className={`mb-4 ${isMobile ? 'mt-6' : ''}`}>
+          <h2 className="font-semibold text-base md:text-lg mb-2">Element Palette</h2>
+          <p className="text-xs md:text-sm text-muted-foreground">
+            Tap elements to add to your README
           </p>
         </div>
       
@@ -251,97 +253,130 @@ export function ElementPalette({ onAddElement }: ElementPaletteProps) {
       />
 
       <Tabs defaultValue="basic" value={activeTab} onValueChange={setActiveTab} className="w-full">
-        <TabsList className="grid grid-cols-2 w-full mb-4">
-          <TabsTrigger value="basic">Basic</TabsTrigger>
-          <TabsTrigger value="advanced">Advanced</TabsTrigger>
+        <TabsList className="grid grid-cols-2 w-full mb-4 gap-1">
+          <TabsTrigger value="basic" className="text-sm">Basic</TabsTrigger>
+          <TabsTrigger value="advanced" className="text-sm">Advanced</TabsTrigger>
         </TabsList>
         
         {/* Basic Elements Tab */}
         <TabsContent value="basic" className="space-y-2">
-          {basicElementTypes.map(({ type, label, icon }) => (
-            <Tooltip key={type}>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleAddElement(type, label)}
-                  className={`w-full justify-start gap-3 h-auto py-3 ${
-                    type === 'tech-stack' ? 'ring-2 ring-primary/50 bg-primary/5' : ''
-                  }`}
-                >
-                  <span className="text-lg">{icon}</span>
-                  <div className="flex-1 text-left">
-                    <div className="font-medium">{label}</div>
-                    <div className="text-xs text-muted-foreground capitalize">{type}</div>
-                  </div>
-                  <Plus className="h-4 w-4 opacity-50" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="text-sm">
-                  {type === 'tech-stack' 
-                    ? 'Add a basic tech stack list - for advanced features use the Advanced tab' 
-                    : `Click to add a ${label.toLowerCase()} element`}
+          {basicElementTypes.map(({ type, label, icon }) => {
+            const button = (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleAddElement(type, label)}
+                className={`w-full justify-start gap-2 md:gap-3 h-auto py-3 touch-manipulation ${
+                  type === 'tech-stack' ? 'ring-2 ring-primary/50 bg-primary/5' : ''
+                }`}
+              >
+                <span className="text-base md:text-lg">{icon}</span>
+                <div className="flex-1 text-left">
+                  <div className="font-medium text-sm md:text-base">{label}</div>
+                  <div className="text-xs text-muted-foreground capitalize">{type}</div>
                 </div>
-              </TooltipContent>
-            </Tooltip>
-          ))}
+                <Plus className="h-4 w-4 opacity-50" />
+              </Button>
+            );
+
+            // Disable tooltips on mobile to prevent overlapping
+            if (isMobile) {
+              return <div key={type}>{button}</div>;
+            }
+
+            return (
+              <Tooltip key={type}>
+                <TooltipTrigger asChild>
+                  {button}
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-sm">
+                    {type === 'tech-stack' 
+                      ? 'Add a basic tech stack list - for advanced features use the Advanced tab' 
+                      : `Click to add a ${label.toLowerCase()} element`}
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
         </TabsContent>
         
         {/* Advanced Elements Tab */}
         <TabsContent value="advanced" className="space-y-2">
           {/* Advanced Tech Stack Creator */}
-          <Tooltip>
-            <TooltipTrigger asChild>
+          {(() => {
+            const button = (
               <Button
                 variant="default"
                 size="sm"
                 onClick={() => setShowTechStackDialog(true)}
-                className="w-full justify-start gap-3 h-auto py-3 mb-4 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700"
+                className="w-full justify-start gap-2 md:gap-3 h-auto py-3 mb-4 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 touch-manipulation"
               >
-                <span className="text-lg">⚡</span>
+                <span className="text-base md:text-lg">⚡</span>
                 <div className="flex-1 text-left">
-                  <div className="font-medium">Advanced Tech Stack</div>
+                  <div className="font-medium text-sm md:text-base">Advanced Tech Stack</div>
                   <div className="text-xs text-white/80">Custom tech badges & styles</div>
                 </div>
                 <Code2 className="h-4 w-4 opacity-80" />
               </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <div className="text-sm">
-                Create a tech stack with custom badge styles, themes, and layouts
-              </div>
-            </TooltipContent>
-          </Tooltip>
+            );
+
+            if (isMobile) {
+              return <div>{button}</div>;
+            }
+
+            return (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  {button}
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-sm">
+                    Create a tech stack with custom badge styles, themes, and layouts
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })()}
 
           <div className="text-sm font-medium text-muted-foreground my-2 pt-2 border-t">
             GitHub Elements
           </div>
           
-          {advancedElementTypes.map(({ type, label, icon, template }) => (
-            <Tooltip key={type}>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() => handleAddAdvancedElement(type, label, template)}
-                  className="w-full justify-start gap-3 h-auto py-3"
-                >
-                  <span className="text-lg">{icon}</span>
-                  <div className="flex-1 text-left">
-                    <div className="font-medium">{label}</div>
-                    <div className="text-xs text-muted-foreground">GitHub API Element</div>
-                  </div>
-                  <Plus className="h-4 w-4 opacity-50" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <div className="text-sm">
-                  Click to add a {label.toLowerCase()} element (GitHub API)
+          {advancedElementTypes.map(({ type, label, icon, template }) => {
+            const button = (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleAddAdvancedElement(type, label, template)}
+                className="w-full justify-start gap-2 md:gap-3 h-auto py-3 touch-manipulation"
+              >
+                <span className="text-base md:text-lg">{icon}</span>
+                <div className="flex-1 text-left">
+                  <div className="font-medium text-sm md:text-base">{label}</div>
+                  <div className="text-xs text-muted-foreground">GitHub API Element</div>
                 </div>
-              </TooltipContent>
-            </Tooltip>
-          ))}
+                <Plus className="h-4 w-4 opacity-50" />
+              </Button>
+            );
+
+            if (isMobile) {
+              return <div key={type}>{button}</div>;
+            }
+
+            return (
+              <Tooltip key={type}>
+                <TooltipTrigger asChild>
+                  {button}
+                </TooltipTrigger>
+                <TooltipContent>
+                  <div className="text-sm">
+                    Click to add a {label.toLowerCase()} element (GitHub API)
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/ReadmePreview.tsx
+++ b/src/components/ReadmePreview.tsx
@@ -9,6 +9,7 @@ import { ElementRenderer } from '@/components/ElementRenderer';
 import type { ElementType } from '@/types/elements';
 import { useTheme } from '@/components/theme-provider';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { useIsMobile } from '@/hooks/use-mobile';
 
 interface ReadmePreviewProps {
   elements: ElementType[];
@@ -24,6 +25,7 @@ export function ReadmePreview({
   const [copied, setCopied] = useState(false);
   const previewRef = useRef<HTMLDivElement>(null);
   const { theme } = useTheme();
+  const isMobile = useIsMobile();
   const isDark =
     theme === 'dark' ||
     (theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches);
@@ -543,54 +545,52 @@ export function ReadmePreview({
 
   return (
     <div className="h-full flex flex-col">
-      <div className="border-b border-border p-4 bg-muted/50">
-        <div className="flex items-center justify-between mb-3">
+      <div className={`border-b border-border p-3 md:p-4 bg-muted/50 ${isMobile ? 'mt-6' : ''}`}>
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-3">
           <div className="flex items-center gap-2">
-            <h3 className="font-medium">README Preview</h3>
+            <h3 className="font-medium text-base md:text-lg">README Preview</h3>
           </div>
           
+          <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto">
+            <select
+              className="border rounded px-2 py-1.5 text-xs md:text-sm bg-background flex-1 sm:flex-initial min-w-[140px]"
+              value={preset}
+              onChange={(e) =>
+                onPresetChange(e.target.value as ReadmeExportPreset)
+              }
+            >
+              <option value="default">Default Export</option>
+              <option value="openSource">Open Source</option>
+              <option value="personal">Personal / Portfolio</option>
+              <option value="professional">Professional</option>
+            </select>
 
-          
-          <div className="flex items-center gap-2">
-  <select
-    className="border rounded px-2 py-1 text-sm bg-background"
-    value={preset}
-    onChange={(e) =>
-      onPresetChange(e.target.value as ReadmeExportPreset)
-    }
-  >
-    <option value="default">Default Export</option>
-    <option value="openSource">Open Source</option>
-    <option value="personal">Personal / Portfolio</option>
-    <option value="professional">Professional</option>
-  </select>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={copyToClipboard}
+              disabled={!filteredElements.length}
+              className="flex-1 sm:flex-initial touch-manipulation"
+            >
+              <Copy className="h-3.5 w-3.5 md:h-4 md:w-4" /> 
+              <span className="ml-1.5">Copy</span>
+            </Button>
 
-  <Button
-    variant="outline"
-    size="sm"
-    onClick={copyToClipboard}
-    disabled={!filteredElements.length}
-  >
-    <Copy className="h-4 w-4" /> Copy
-  </Button>
+            {copied && <span className="text-green-500 text-xs md:text-sm">Copied!</span>}
 
-  {copied && <span className="text-green-500 text-sm">Copied!</span>}
-
-  <Button
-    variant="outline"
-    size="sm"
-    onClick={downloadMarkdown}
-    disabled={!filteredElements.length}
-  >
-    <Download className="h-4 w-4" /> Download
-  </Button>
-</div>
-
-
-
-
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={downloadMarkdown}
+              disabled={!filteredElements.length}
+              className="flex-1 sm:flex-initial touch-manipulation"
+            >
+              <Download className="h-3.5 w-3.5 md:h-4 md:w-4" /> 
+              <span className="ml-1.5">Download</span>
+            </Button>
+          </div>
         </div>
-        <p className="text-sm text-muted-foreground">{getViewModeDescription()}</p>
+        <p className="text-xs md:text-sm text-muted-foreground">{getViewModeDescription()}</p>
       </div>
 
       <Tabs defaultValue="preview" className="flex-1 flex flex-col">


### PR DESCRIPTION
# 🛠 Pull Request 


## 📌 Related Issue


Fixes: #350 

## 🔍 Describe your changes?

This PR fixes unreliable drag-and-drop behavior on mobile viewports by introducing a conditional UI and improves the Sidebar layout for better responsiveness.

Mobile Reordering Fix (Viewports < 768px)
Reordering Logic: Replaced drag-and-drop with "Move Up/Down" arrow buttons to prevent conflicts with browser scrolling.

UI Visibility: Edit/Delete buttons are now always visible on mobile (no hover required).
Implementation: Used a useIsMobile hook to toggle between button-based controls and desktop drag-and-drop.

Sidebar & Palette Enhancements
Layout Fixes: Resolved horizontal overflow in the Element Palette using truncate, min-w-0, and overflow-x-hidden.
Responsive Widths: 
Desktop: Increased width to w-80 (320px) for better tab readability.
Tablet: Locked sidebar to w-64 (256px) with optimized padding and font sizes.
Polished Styling: Updated background tokens and added flex-shrink-0 to icons to ensure they don't squash on smaller screens.


---


## 📸 Screenshot

https://github.com/user-attachments/assets/daef4eec-db17-4fe1-9162-5d1dbedb82cb

![WhatsApp Image 2026-01-14 at 00 28 38](https://github.com/user-attachments/assets/35dc034b-19ea-4832-be56-e503412f53d0)

---


## 🧪 Checklist

Please check all that apply:

- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.


