### PR TITLE
fix(navbar): prevent layout shift by disabling modal behavior on More…

### DIFF
--- a/src/components/_components/header.tsx
+++ b/src/components/_components/header.tsx
@@ -69,7 +69,7 @@ export const Header = () => {
                 Elements
               </Link>
 
-              <DropdownMenu>
+              <DropdownMenu modal={false}>
                 <DropdownMenuTrigger asChild>
                   <button className={navItemClass}>
                     More


### PR DESCRIPTION
## Related Issue
Fixes #379

---

## What changed?
Fixed a small UI glitch where the navbar would shift slightly to the right when clicking the **More** dropdown.  
The issue was caused by the dropdown’s default modal behavior locking page scroll, which affected the layout width.

The dropdown is now configured to behave like a normal navigation menu without altering page scroll, keeping the navbar stable.

---

## Testing
- Tested locally on desktop (Chrome)
- Verified the navbar no longer shifts when opening or closing the **More** dropdown