### PR TITLE
Fix Advanced Tech Stack Generator modal overlapping with navbar

### DIFF
--- a/src/components/TechStackDialog.tsx
+++ b/src/components/TechStackDialog.tsx
@@ -42,7 +42,7 @@ export function TechStackDialog({ isOpen, onClose, onAddElement }: TechStackDial
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-w-2xl max-h-[calc(100vh-96px)] overflow-y-auto mt-16">
         <DialogHeader>
           <DialogTitle>Advanced Tech Stack Generator</DialogTitle>
           <DialogDescription>


### PR DESCRIPTION
## Description
Fixes an issue where the Advanced Tech Stack Generator dialog overlapped
with the fixed editor navbar, causing parts of the modal to be hidden.

## Changes Made
- Added a top offset to the dialog content
- Ensured the modal opens fully below the navbar
- Preserved scroll behavior and responsiveness

## Screenshots
Before: Modal overlapped the navbar  
After: Modal opens correctly below the navbar

## Related Issue
Closes #390

<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/4546329a-e13a-4f88-b7cb-445d2a547979" />
