### PR TITLE
Integrate README quality score into drag-and-drop editor

### DIFF
--- a/src/components/ReadmeQualityDialog.tsx
+++ b/src/components/ReadmeQualityDialog.tsx
@@ -1,0 +1,78 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import type { ReadmeQualityResult } from '@/utils/readmeQualityAnalyzer';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  result: ReadmeQualityResult | null;
+}
+
+export function ReadmeQualityDialog({ open, onClose, result }: Props) {
+  if (!result) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>README Quality Report</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <span className="text-4xl font-bold">{result.score}</span>
+            <Badge
+            className={
+                result.score >= 70
+                ? 'bg-green-600 text-white'
+                : 'bg-yellow-500 text-black'
+               }
+            >
+           / 100
+          </Badge>
+          </div>
+
+          <div>
+            <h4 className="font-semibold">Strengths</h4>
+            <ul className="list-disc list-inside text-sm">
+              {result.strengths.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+          </div>
+
+          {result.missing.length > 0 && (
+            <div>
+              <h4 className="font-semibold">Missing / Weak Areas</h4>
+              <ul className="list-disc list-inside text-sm">
+                {result.missing.map((m, i) => (
+                  <li key={i}>{m}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div>
+            <h4 className="font-semibold">Suggestions</h4>
+            <ul className="list-disc list-inside text-sm">
+              {result.suggestions.map((s, i) => (
+                <li key={i}>{s}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onClose}>Close</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/utils/readmeQualityAnalyzer.ts
+++ b/src/utils/readmeQualityAnalyzer.ts
@@ -1,0 +1,80 @@
+import type { ElementType } from '@/types/elements';
+
+export interface ReadmeQualityResult {
+  score: number;
+  strengths: string[];
+  missing: string[];
+  suggestions: string[];
+}
+
+export function analyzeReadmeQuality(
+  elements: ElementType[]
+): ReadmeQualityResult {
+  let score = 0;
+  const strengths: string[] = [];
+  const missing: string[] = [];
+  const suggestions: string[] = [];
+
+  const types: ElementType['type'][] = elements.map(e => e.type);
+
+  const has = (t: ElementType['type']) => types.includes(t);
+
+  if (has('title') || has('header')) {
+    score += 15;
+    strengths.push('Project title is present');
+  } else {
+    missing.push('Project title');
+    suggestions.push('Add a clear project title using a Header element');
+  }
+
+  if (has('description') || has('text')) {
+    score += 15;
+    strengths.push('Project description is present');
+  } else {
+    missing.push('Description');
+    suggestions.push(
+      'Add a short description explaining what the project does'
+    );
+  }
+
+  if (has('installation')) {
+    score += 15;
+    strengths.push('Installation instructions provided');
+  } else {
+    missing.push('Installation');
+    suggestions.push('Add installation steps to help users get started');
+  }
+
+  if (has('code-block')) {
+    score += 15;
+    strengths.push('Usage examples included');
+  } else {
+    suggestions.push('Include code examples to improve usability');
+  }
+
+  if (has('tech-stack')) {
+    score += 10;
+    strengths.push('Tech stack documented');
+  } else {
+    suggestions.push('Document the technologies used in the project');
+  }
+
+  if (has('badge')) {
+    score += 5;
+    strengths.push('Badges improve visual clarity');
+  }
+
+  if (elements.length >= 5) {
+    score += 10;
+    strengths.push('README has a good structural depth');
+  } else {
+    suggestions.push('Consider adding more structured sections');
+  }
+
+  return {
+    score: Math.min(score, 100),
+    strengths,
+    missing,
+    suggestions,
+  };
+}


### PR DESCRIPTION

## 📌 Related Issue

Fixes: #391  

---

## 🔍 Describe your changes?

This PR adds a **README Quality Score** feature to the drag-and-drop README editor.

### Key changes:
- Introduced a rule-based README quality analyzer that evaluates structure and content
- Added a **“Check README Quality”** action in the editor
- Implemented a modal dialog displaying:
  - Overall score (0–100)
  - Strengths
  - Missing or weak sections
  - Actionable improvement suggestions
- Integrated the analyzer seamlessly with existing editor elements

This helps users improve their README **before exporting**, enhancing usability and quality.

---

## 📸 Screenshot
<img width="1919" height="926" alt="image" src="https://github.com/user-attachments/assets/08e788db-4912-4ae2-b965-2c28c1638150" />
<img width="1914" height="916" alt="image" src="https://github.com/user-attachments/assets/7db57078-bd9d-4925-a749-de48dc82c1db" />
<img width="1919" height="927" alt="image" src="https://github.com/user-attachments/assets/395b4096-3c59-4695-bdd6-af4a54edc509" />

---

## 🧪 Checklist

Please check all that apply:

- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.

---

## 🗒️ Additional Notes (Optional)

- The analyzer is rule-based and lightweight (no backend or AI dependency).
- Designed to be easily extensible for future AI-based enhancements.
- Feature required coordinated updates across editor UI, utility logic, and modal components.

Requesting **Medium-level** consideration due to multi-component integration and logic implementation.

