### PR TITLE
fix: redirect Documentation link to GitHub docs

### DIFF
--- a/src/components/QuickStartGuide.tsx
+++ b/src/components/QuickStartGuide.tsx
@@ -60,7 +60,10 @@ export function QuickStartGuide({ onStartFromScratch }: QuickStartGuideProps) {
           </CommandGroup>
 
           <CommandGroup heading="Help">
-            <CommandItem onSelect={() => handleNavigation('/docs')}>
+            <CommandItem onSelect={() => 
+               window.open(
+                  'https://github.com/Mayur-Pagote/README_Design_Kit/tree/main/docs','_blank'
+                )}>
               <Text className="mr-3 h-5 w-5" />
               <span className="text-base">Documentation</span>
             </CommandItem>


### PR DESCRIPTION
# 🛠 Description

Problem

-Clicking Documentation routes internally to /docs
-/docs is not an existing route
-Users see a 404 error, which is confusing for first-time users

The link is now updated to open the official GitHub documentation in a new tab.

## 📌 Related Issue

Fixes: #464   


---



## 🔍 Describe your changes?

Replaced internal navigation to /docs with an external GitHub documentation link
Ensured the link opens in a new tab to avoid breaking the current user flow
Improved overall UX by preventing 404 errors for users seeking help


---



## 📸 Video



https://github.com/user-attachments/assets/ca704b06-af95-4b2e-b186-c47b09de9b11





---


## 🧪 Checklist


Please check all that apply:


- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)

I am an SWOC'26 Contributor.


---

