### PR TITLE
Fix non-functional Watch Tutorial Video action

### DIFF
--- a/src/components/generator/FinalPage.tsx
+++ b/src/components/generator/FinalPage.tsx
@@ -326,7 +326,14 @@ const FinalPage = ({ state, goToPage }: FinalPageProps) => {
                 </div>
 
                 <div className="text-center text-sm text-slate-400 space-y-2">
-                  <p>Need help? <a href="#" className="text-purple-400 hover:text-purple-300">Watch tutorial video</a></p>
+                  <p>Need help?{' '}
+                    <span
+                    className="text-purple-400 opacity-60 cursor-not-allowed text-sm"
+                    title="Tutorial video coming soon"
+                    >
+                      Watch tutorial video (Coming soon)
+                    </span>
+                  </p>
                   <p>Hey 👋 Help us grow by sharing! 🙏</p>
                 </div>
               </div>


### PR DESCRIPTION



## 📌 Related Issue

Fixes: **#494**

---

## 🔍 Describe your changes?

* Removed the non-functional **“Watch tutorial video”** link on the final README generator page.
* Replaced it with a disabled **“Coming soon”** indicator to prevent a dead interaction.
* Ensured the UI clearly communicates that the tutorial is not yet available.

---

## 📸 Screenshot

![Watch tutorial video coming soon](https://github.com/user-attachments/assets/04115ce2-ad7e-40e9-a362-1daca0ef0858)

---

## 🧪 Checklist

* [x] I have tested my changes locally.
* [x] I have followed the project's code style and guidelines.
* [x] I have added necessary comments and documentation.
* [x] The code compiles and runs without errors.

---

## 🗒️ Additional Notes (Optional)

* This change keeps the fix minimal and avoids assumptions about a tutorial URL.
* Tested end-to-end using GitHub Codespaces.

