### PR TITLE
Fixed Template Preview Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import Home from "./pages/Home";
 import Layout from "./components/Layout";
 import ScrollToTop from "./components/ScrollToTop";
+import ScrollRestoration from "./components/ScrollRestoration";
 import Elements from "./pages/Elements";
 // import Hero from "./pages/Hero";
 import ProjectsSection from "./components/ProjectsSection";
@@ -46,6 +47,7 @@ export default function App() {
         <ThemeProvider defaultTheme="system" storageKey="readme-design-kit-theme">
           <Cursortrail />
           <BrowserRouter>
+            <ScrollRestoration />
             <ConditionalScrollToTop />
             <Routes>
               {/* Routes with Layout (navbar + footer) */}

--- a/src/components/MarkdownCode.tsx
+++ b/src/components/MarkdownCode.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { toast } from 'sonner';
 import { Button } from './ui/button';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -31,16 +31,12 @@ const cleanMarkdown = (markdown: string) => {
 };
 
 const MarkdownCode = ({ markdown }: MarkdownCodeProps) => {
-  const [isCopied, setIsCopied] = useState(false);
 
   const content = cleanMarkdown(markdown);
 
   const handleCopy = () => {
     navigator.clipboard.writeText(content);
-    setIsCopied(true);
-    setTimeout(() => {
-      setIsCopied(false);
-    }, 1500);
+    toast.success("Markdown copied to clipboard");
   };
 
   return (
@@ -51,12 +47,11 @@ const MarkdownCode = ({ markdown }: MarkdownCodeProps) => {
       <Button
         onClick={handleCopy}
         className={cn(
-          "absolute top-2 right-2",
-          isCopied && "bg-green-500 text-white hover:bg-green-600"
+          "absolute top-2 right-2"
         )}
         variant="secondary"
       >
-        {isCopied ? 'Copied!' : 'Copy'}
+        COPY CODE
       </Button>
     </div>
   );

--- a/src/components/ScrollRestoration.tsx
+++ b/src/components/ScrollRestoration.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollRestoration() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/TemplateLibrary/TemplateLibrary.tsx
+++ b/src/components/TemplateLibrary/TemplateLibrary.tsx
@@ -5,8 +5,6 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { TemplatePreview } from './TemplatePreview';
 import { useTemplatePreferences } from '@/hooks/useTemplatePreferences';
 import { sampleTemplates, templateCategories, popularTags } from '@/data/templates';
 import type { Template, TemplateCategory } from '@/types/templates';
@@ -27,12 +25,9 @@ export function TemplateLibrary({ onSelectTemplate, onStartFromScratch }: Templa
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   
-  // State for the Preview Popup
-  const [previewTemplate, setPreviewTemplate] = useState<Template | null>(null);
-  
   const [activeTab, setActiveTab] = useState('all');
   
-  const { preferences, toggleFavorite: toggleTemplateFavorite, addToRecentlyViewed, addToRecentlyUsed } = useTemplatePreferences();
+  const { preferences, toggleFavorite: toggleTemplateFavorite, addToRecentlyViewed } = useTemplatePreferences();
   
   // Filter templates based on current filters and active tab
   const filteredTemplates = useMemo(() => {
@@ -89,19 +84,6 @@ export function TemplateLibrary({ onSelectTemplate, onStartFromScratch }: Templa
   };
 
   // --- ACTIONS ---
-
-  // Triggered when "Use This Template" is clicked INSIDE the popup
-  const handleConfirmUseTemplate = (template: Template) => {
-    addToRecentlyUsed(template.id);
-    onSelectTemplate(template, username, repo);
-    setPreviewTemplate(null);
-  };
-
-  // Triggered when a card is clicked in the grid
-  const handleCardClick = (template: Template) => {
-    addToRecentlyViewed(template.id);
-    setPreviewTemplate(template); // Opens the popup
-  };
 
   const handleUsernameChange = (newUsername: string) => {
     setUsername(newUsername);
@@ -273,7 +255,10 @@ export function TemplateLibrary({ onSelectTemplate, onStartFromScratch }: Templa
                 key={template.id}
                 template={template}
                 isFavorite={preferences.favorites.includes(template.id)}
-                onSelect={() => handleCardClick(template)} 
+                onSelect={() => {
+                addToRecentlyViewed(template.id);
+                onSelectTemplate(template, username, repo);
+              }} 
                 onToggleFavorite={() => toggleFavorite(template.id)}
               />
             ))}
@@ -285,8 +270,14 @@ export function TemplateLibrary({ onSelectTemplate, onStartFromScratch }: Templa
                 key={template.id}
                 template={template}
                 isFavorite={preferences.favorites.includes(template.id)}
-                onSelect={() => handleCardClick(template)}
-                onPreview={() => handleCardClick(template)}
+                onSelect={() => {
+                addToRecentlyViewed(template.id);
+                onSelectTemplate(template, username, repo);
+              }}
+                onPreview={() => {
+                  addToRecentlyViewed(template.id);
+                  onSelectTemplate(template, username, repo);
+                }}
                 onToggleFavorite={() => toggleFavorite(template.id)}
               />
             ))}
@@ -302,24 +293,6 @@ export function TemplateLibrary({ onSelectTemplate, onStartFromScratch }: Templa
           </div>
         )}
       </div>
-
-      {/* Template Preview Dialog - PERFECT BOX */}
-      <Dialog open={!!previewTemplate} onOpenChange={() => setPreviewTemplate(null)}>
-        {/* max-w-[95vw] and h-[90vh] makes it a big professional window */}
-        <DialogContent className="template-scroll max-w-[95vw] w-[1400px] h-[90vh] overflow-hidden p-0 gap-0 border-none bg-background/95 backdrop-blur-xl">
-          <DialogHeader className="sr-only">
-            <DialogTitle>{previewTemplate?.name}</DialogTitle>
-          </DialogHeader>
-          {previewTemplate && (
-            <div className="h-full overflow-hidden p-6">
-              <TemplatePreview
-                template={previewTemplate}
-                onUseTemplate={() => handleConfirmUseTemplate(previewTemplate)}
-              />
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
     </div>
   );
 }

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { GripVerticalIcon } from "lucide-react"
+import { ChevronsLeftRightEllipsis } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"
@@ -37,14 +37,14 @@ function ResizableHandle({
     <ResizablePrimitive.PanelResizeHandle
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring relative flex w-px items-start pt-4 justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
         className
       )}
       {...props}
     >
       {withHandle && (
-        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
-          <GripVerticalIcon className="size-2.5" />
+        <div className="bg-border z-10 flex h-8 w-12 items-center justify-center rounded-sm border">
+          <ChevronsLeftRightEllipsis className="size-6.5" />
         </div>
       )}
     </ResizablePrimitive.PanelResizeHandle>

--- a/src/pages/MarkdownEditor.tsx
+++ b/src/pages/MarkdownEditor.tsx
@@ -2,27 +2,122 @@ import { useLocation } from 'react-router-dom';
 import MarkdownPreview from '../components/MarkdownPreview';
 import MarkdownCode from '../components/MarkdownCode';
 import {ResizablePanelGroup, ResizablePanel, ResizableHandle} from '@/components/ui/resizable';
+import type { Template } from '@/types/templates';
+import { templateCategories } from '@/data/templates';
+import { Badge } from '@/components/ui/badge';
+import { Calendar, Code2, Github, Settings2, User } from 'lucide-react';
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Separator } from '@/components/ui/separator';
 
 const MarkdownEditor = () => {
   const location = useLocation();
-  const markdown = location.state?.markdown || '# No template selected';
+  const { template, username: initialUsername, repo: initialRepo } = (location.state as { template: Template, username: string, repo: string }) || {};
+
+  const [username, setUsername] = useState(initialUsername || 'Mayur-Pagote');
+  const [repoName, setRepoName] = useState(initialRepo || 'README_Design_Kit');
+  
+  const usernameTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const repoNameTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const debouncedSetUsername = useCallback((value: string) => {
+    if (usernameTimeoutRef.current) clearTimeout(usernameTimeoutRef.current);
+    usernameTimeoutRef.current = setTimeout(() => {
+      setUsername(value);
+    }, 300);
+  }, []);
+
+  const debouncedSetRepoName = useCallback((value: string) => {
+    if (repoNameTimeoutRef.current) clearTimeout(repoNameTimeoutRef.current as unknown as number);
+    repoNameTimeoutRef.current = setTimeout(() => {
+      setRepoName(value);
+    }, 300);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (usernameTimeoutRef.current) clearTimeout(usernameTimeoutRef.current as unknown as number);
+      if (repoNameTimeoutRef.current) clearTimeout(repoNameTimeoutRef.current as unknown as number);
+    };
+  }, []);
+
+  const categoryLabel = templateCategories.find(c => c.value === template.category)?.label;
+
+  const markdownContent = template?.markdown || '# No template selected';
+  
+  const finalMarkdown = template 
+    ? markdownContent.replace(/{username}/g, username || '').replace(/{repo}/g, repoName || '')
+    : markdownContent;
 
   return (
-    <ResizablePanelGroup direction="horizontal" className="min-h-screen">
-      <ResizablePanel>
-        <div className="h-full p-4 overflow-auto">
-          <h2 className="text-2xl font-bold mb-4">Markdown Preview</h2>
-          <MarkdownPreview markdown={markdown} />
+    <>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <Badge variant="outline" className="w-fit mb-2">
+              {categoryLabel}
+          </Badge>
+          <h2 className="text-3xl font-bold leading-tight">{template.name}</h2>
+          <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <span className="flex items-center gap-1"><User className="h-3 w-3" /> {template.author}</span>
+              <span className="flex items-center gap-1">•</span>
+              <span className="flex items-center gap-1"><Calendar className="h-3 w-3" /> {template.updated.toLocaleDateString()}</span>
+          </div>
         </div>
-      </ResizablePanel>
-      <ResizableHandle withHandle />
-      <ResizablePanel>
-        <div className="h-full p-4 overflow-auto">
-          <h2 className="text-2xl font-bold mb-4">Markdown Code</h2>
-          <MarkdownCode markdown={markdown} />
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          {template.description}
+        </p>
+      </div>
+      <Separator />
+      <div className="space-y-4 flex-1 m-2">
+          <div className="flex items-center gap-2 text-sm font-semibold text-primary/80 uppercase tracking-wider">
+            <Settings2 className="h-4 w-4" />
+            <span>Configuration</span>
+          </div>
+          
+          <div className="grid gap-4 bg-muted/30 p-4 rounded-xl border">
+            <div className="space-y-1.5">
+              <label className="text-[11px] font-bold uppercase text-muted-foreground flex items-center gap-2">
+                <Github className="h-3 w-3" /> GitHub Username
+              </label>
+              <Input 
+                defaultValue={username}
+                onChange={(e) => debouncedSetUsername(e.target.value)}
+                className="h-9 text-sm bg-background"
+                placeholder="e.g. Mayur-Pagote"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label className="text-[11px] font-bold uppercase text-muted-foreground flex items-center gap-2">
+                <Code2 className="h-3 w-3" /> Repository Name
+              </label>
+              <Input 
+                defaultValue={repoName}
+                onChange={(e) => debouncedSetRepoName(e.target.value)}
+                className="h-9 text-sm bg-background"
+                placeholder="e.g. README_Design_Kit"
+              />
+            </div>
+          </div>
         </div>
-      </ResizablePanel>
-    </ResizablePanelGroup>
+      <ResizablePanelGroup direction="horizontal" className="min-h-screen">
+        <ResizablePanel>
+          <div className="h-full p-4 overflow-auto">
+            <h2 className="text-2xl font-bold mb-4">
+              Markdown Preview
+            </h2>
+            <MarkdownPreview markdown={finalMarkdown} />
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel>
+          <div className="h-full p-4 overflow-auto">
+            <h2 className="text-2xl font-bold mb-4">Markdown Code</h2>
+            <MarkdownCode markdown={finalMarkdown} />
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    </>
   );
 };
 

--- a/src/pages/TemplateLibraryPage.tsx
+++ b/src/pages/TemplateLibraryPage.tsx
@@ -10,12 +10,8 @@ export default function TemplateLibraryPage() {
     username: string,
     repo: string,
   ) => {
-    const markdown = template.markdown || "";
-    const finalMarkdown = markdown
-      .replace(/{username}/g, username)
-      .replace(/{repo}/g, repo);
-    // Navigate to the markdown editor
-    navigate("/markdown-editor", { state: { markdown: finalMarkdown } });
+    // Navigate to the markdown editor, passing the full template and context
+    navigate("/markdown-editor", { state: { template, username, repo } });
   };
 
   const handleStartFromScratch = () => {


### PR DESCRIPTION
# 🛠 Pull Request


## 📌 Related Issue


Fixes: #487


---




## 🔍 Describe your changes?

- Fixed template preview page to be viewable on all devices.
- Add resizable handler so that template can be pre-viewed for any screen type.
- Added debouncing on user input for username and repository name for better responsiveness of markdown preview.
- Implemented toast notification on copying markdown code.
- Added scroll restoration for fixing issue of pages not starting from top when navigating to them.


---


## 📸 Screenshot


<img width="1901" height="969" alt="Screenshot 2026-02-01 223220" src="https://github.com/user-attachments/assets/e64f7c0e-0486-4ab8-8112-a77b9239dfd6" />
<img width="1898" height="967" alt="Screenshot 2026-02-01 223423" src="https://github.com/user-attachments/assets/21606cd8-60ba-4596-b1c0-9cda27769d10" />

https://github.com/user-attachments/assets/f611547a-43c0-4fde-a217-e9462261d215


---


## 🧪 Checklist


Please check all that apply:


- [☑️] I have tested my changes locally.
- [☑️] I have followed the project's code style and guidelines.
- [☑️] I have added necessary comments and documentation.
- [☑️] The code compiles and runs without errors.