### PR TITLE
Fix clutter between navbar and progress status

### DIFF
--- a/src/components/generator/ProgressIndicator.tsx
+++ b/src/components/generator/ProgressIndicator.tsx
@@ -10,10 +10,10 @@ const ProgressIndicator = ({ current, total }: ProgressIndicatorProps) => {
   const progress = ((current) / total) * 100;
 
   return (
-    <div className="mb-8">
+    <div className="mb-8 mt-6">
       <div className="flex justify-between items-center mb-2">
-        <span className="text-sm text-muted-foreground">Progress</span>
-        <span className="text-sm text-muted-foreground">{current}/{total}</span>
+        <span className="text-sm text-white text-muted-foreground">Progress</span>
+        <span className="text-sm text-white text-muted-foreground">{current}/{total}</span>
       </div>
       <div className="w-full bg-slate-800 rounded-full h-2 overflow-hidden">
         <motion.div


### PR DESCRIPTION
# 🛠 Pull Request Template


## 📌 Related Issue


Fixes: #538   


---




## 🔍 Describe your changes?


while using Readme Generator the progress status showing bar was appearing immediately below navbar making it cluttered and crowded.

Made the progress status bar to be in small gap with the navbar so that it doesn't look cluttered and crowded. and the text colour of progress was in contrast so changed it to white to make it look better in both dark and light view.

---


## 📸 Screenshot


Before
<img width="1801" height="355" alt="image" src="https://github.com/user-attachments/assets/a2544504-14e6-4730-91eb-8527f28ea515" />





After 
<img width="1861" height="505" alt="image" src="https://github.com/user-attachments/assets/7bae1fc8-f7c8-4b35-ad05-75e6b005a92c" />


<img width="1741" height="428" alt="image" src="https://github.com/user-attachments/assets/b0d75118-7967-4f2a-87a4-b793fc5fe032" />



---


## 🧪 Checklist


Please check all that apply:


- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)




---



---

