### PR TITLE
fix completed status and navbar overlap

### DIFF
--- a/src/components/generator/FinalPage.tsx
+++ b/src/components/generator/FinalPage.tsx
@@ -188,7 +188,7 @@ const FinalPage = ({ state, goToPage }: FinalPageProps) => {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <div className="container mx-auto px-4 py-8 flex-1">
+      <div className="container mx-auto px-4 py-16 flex-1">
         <div className="max-w-6xl mx-auto">
           <motion.div
             initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
# 🛠 Pull Request Template


## 📌 Related Issue


Fixes: #572   


---




## 🔍 Describe your changes?

The README Generator feature, the final step shows a Completed status indicator. However, this indicator overlaps with the navbar, making the UI look cluttered and visually unappealing. Changed this to give gap between Navbar and Completed.


---


## 📸 Screenshot

<img width="1840" height="820" alt="image" src="https://github.com/user-attachments/assets/8a4d7974-1e83-4734-b6da-905999200b7d" />




---


## 🧪 Checklist


Please check all that apply:


- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)


Let me know if you need any changes.

---




---

