### PR TITLE
fix redirection of github in Need help getting started section

### DIFF
--- a/src/components/QuickStartGuide.tsx
+++ b/src/components/QuickStartGuide.tsx
@@ -64,7 +64,9 @@ export function QuickStartGuide({ onStartFromScratch }: QuickStartGuideProps) {
               <Text className="mr-3 h-5 w-5" />
               <span className="text-base">Documentation</span>
             </CommandItem>
-            <CommandItem onSelect={() => handleNavigation('/about')}>
+            <CommandItem onSelect={() => window.open(
+                  'https://github.com/Mayur-Pagote/README_Design_Kit','_blank'
+                )}>
               <GithubIcon className="mr-3 h-5 w-5" />
               <span className="text-base">Github</span>
             </CommandItem>


### PR DESCRIPTION
# 🛠 Pull Request Template


## 📌 Related Issue

Fixes #596 




---




## 🔍 Describe your changes?
Earlier on clicking the github in Need help getting started section was redirecting it to About us page. Changed it and made github to redirect to its official Repository.



---


## 📸 Screenshot


<img width="1904" height="948" alt="image" src="https://github.com/user-attachments/assets/4b589ed8-0010-4e67-a377-2c34d46b2d41" />

<img width="1792" height="919" alt="image" src="https://github.com/user-attachments/assets/f596469a-7081-47df-bb36-0fd9a12449ad" />


---


## 🧪 Checklist


Please check all that apply:


- [x] I have tested my changes locally.
- [x] I have followed the project's code style and guidelines.
- [x] I have added necessary comments and documentation.
- [x] The code compiles and runs without errors.




---


## 🗒️ Additional Notes (Optional)

SWOC'26 Contribuotr


---


