### PR TITLE
Extract hardcoded repository path to config & add contributors pagination

### DIFF
--- a/src/components/_components/about.tsx
+++ b/src/components/_components/about.tsx
@@ -7,6 +7,17 @@ import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Github, Code, Palette, Zap, LayoutGrid, Code2, Sparkles, Users, BookOpen, GitBranch, ShieldCheck, Heart, Loader2, AlertCircle } from "lucide-react";
 import { fetchContributors } from '@/lib/github';
+import { siteConfig } from '@/config/site';
+
+// 1. Import Pagination components
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
 
 interface Contributor {
     login: string;
@@ -20,12 +31,18 @@ export default function AboutUs() {
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
+    // 2. Add Pagination State
+    const [currentPage, setCurrentPage] = useState(1);
+    
+    // Set to 30 to show 5 rows on large screens (5 rows * 6 columns = 30 items)
+    // If you literally meant 5 items total per page, change this to 5.
+    const ITEMS_PER_PAGE = 30; 
+
     useEffect(() => {
         const loadContributors = async () => {
             try {
                 setIsLoading(true);
-                // Replace 'owner/repo' with your GitHub repository path
-                const data = await fetchContributors('Code-writter/README_Design_Kit');
+                const data = await fetchContributors(siteConfig.githubRepo);
                 setContributors(data);
             } catch (err) {
                 console.error('Failed to load contributors:', err);
@@ -64,37 +81,91 @@ export default function AboutUs() {
             );
         }
 
+        // 3. Calculate Pagination Data
+        const totalPages = Math.ceil(contributors.length / ITEMS_PER_PAGE);
+        const startIndex = (currentPage - 1) * ITEMS_PER_PAGE;
+        const currentContributors = contributors.slice(startIndex, startIndex + ITEMS_PER_PAGE);
+
         return (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-                {contributors.map((contributor) => (
-                    <a
-                        key={contributor.login}
-                        href={contributor.html_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="group"
-                    >
-                        <Card className="h-full transition-all hover:shadow-lg hover:border-primary">
-                            <CardHeader className="p-4">
-                                <div className="flex flex-col items-center text-center">
-                                    <Avatar className="w-16 h-16 mb-3 group-hover:ring-2 group-hover:ring-primary group-hover:ring-offset-2 transition-all">
-                                        <AvatarImage src={contributor.avatar_url} />
-                                        <AvatarFallback>{contributor.login[0].toUpperCase()}</AvatarFallback>
-                                    </Avatar>
-                                    <CardTitle className="text-base font-medium group-hover:text-primary transition-colors">
-                                        {contributor.login}
-                                    </CardTitle>
-                                    <CardDescription className="text-xs">
-                                        {contributor.contributions} {contributor.contributions === 1 ? 'contribution' : 'contributions'}
-                                    </CardDescription>
-                                </div>
-                            </CardHeader>
-                        </Card>
-                    </a>
-                ))}
+            <div className="space-y-8">
+                {/* 4. Render only the current slice of contributors */}
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                    {currentContributors.map((contributor) => (
+                        <a
+                            key={contributor.login}
+                            href={contributor.html_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="group"
+                        >
+                            <Card className="h-full transition-all hover:shadow-lg hover:border-primary">
+                                <CardHeader className="p-4">
+                                    <div className="flex flex-col items-center text-center">
+                                        <Avatar className="w-16 h-16 mb-3 group-hover:ring-2 group-hover:ring-primary group-hover:ring-offset-2 transition-all">
+                                            <AvatarImage src={contributor.avatar_url} />
+                                            <AvatarFallback>{contributor.login[0].toUpperCase()}</AvatarFallback>
+                                        </Avatar>
+                                        <CardTitle className="text-base font-medium group-hover:text-primary transition-colors">
+                                            {contributor.login}
+                                        </CardTitle>
+                                        <CardDescription className="text-xs">
+                                            {contributor.contributions} {contributor.contributions === 1 ? 'contribution' : 'contributions'}
+                                        </CardDescription>
+                                    </div>
+                                </CardHeader>
+                            </Card>
+                        </a>
+                    ))}
+                </div>
+
+                {/* 5. Pagination Controls */}
+                {totalPages > 1 && (
+                    <Pagination>
+                        <PaginationContent>
+                            <PaginationItem>
+                                <PaginationPrevious 
+                                    href="#" 
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        if (currentPage > 1) setCurrentPage(p => p - 1);
+                                    }}
+                                    className={currentPage === 1 ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                                />
+                            </PaginationItem>
+                            
+                            {/* Render page numbers */}
+                            {Array.from({ length: totalPages }).map((_, i) => (
+                                <PaginationItem key={i}>
+                                    <PaginationLink 
+                                        href="#"
+                                        onClick={(e) => {
+                                            e.preventDefault();
+                                            setCurrentPage(i + 1);
+                                        }}
+                                        isActive={currentPage === i + 1}
+                                    >
+                                        {i + 1}
+                                    </PaginationLink>
+                                </PaginationItem>
+                            ))}
+
+                            <PaginationItem>
+                                <PaginationNext 
+                                    href="#" 
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        if (currentPage < totalPages) setCurrentPage(p => p + 1);
+                                    }}
+                                    className={currentPage === totalPages ? "pointer-events-none opacity-50" : "cursor-pointer"}
+                                />
+                            </PaginationItem>
+                        </PaginationContent>
+                    </Pagination>
+                )}
             </div>
         );
     };
+
     const features = [
         {
             icon: <Code2 className="w-6 h-6" />,
@@ -127,18 +198,16 @@ export default function AboutUs() {
             description: "Pre-built components for badges, tables, code blocks, and more"
         },
         {
-  icon: <Zap className="w-6 h-6" />,
-  title: "Live Preview",
-  description: "Instantly preview your README as it will appear on GitHub"
-},
-{
-  icon: <Code className="w-6 h-6" />,
-  title: "Export & Download",
-  description: "Export README files in Markdown format with a single click"
-}
+            icon: <Zap className="w-6 h-6" />,
+            title: "Live Preview",
+            description: "Instantly preview your README as it will appear on GitHub"
+        },
+        {
+            icon: <Code className="w-6 h-6" />,
+            title: "Export & Download",
+            description: "Export README files in Markdown format with a single click"
+        }
     ];
-
-    // Team section now uses the renderContributors function to display GitHub contributors
 
     return (
         <div className="container mx-auto px-4 py-12 md:py-20">
@@ -160,10 +229,9 @@ export default function AboutUs() {
                         </Link>
                     </Button>
                     <Button asChild variant="outline" size="lg" className="gap-2">
-                        <a href="https://github.com/Mayur-Pagote/README_Design_Kit" target="_blank">
+                        <a href={siteConfig.githubUrl} target="_blank" rel="noopener noreferrer">
                             <Github className="w-4 h-4" /> GitHub
                         </a>
-                            
                     </Button>
                </div>
             </section>
@@ -241,12 +309,12 @@ export default function AboutUs() {
                     </p>
                 </div>
                 {renderContributors()}
-                <div className="text-center mt-8">
+                <div className="text-center mt-12">
                     <p className="text-sm text-muted-foreground mb-4">
                         Want to see your face here? Contribute to our project on GitHub!
                     </p>
                     <Button asChild variant="outline" className="gap-2">
-                        <a href="https://github.com/Mayur-Pagote/README_Design_Kit" target="_blank">
+                        <a href={siteConfig.githubUrl} target="_blank" rel="noopener noreferrer">
                             <Github className="w-4 h-4" /> Contribute Now
                         </a>
                     </Button>
@@ -266,7 +334,7 @@ export default function AboutUs() {
                         </Link>
                     </Button>
                     <Button asChild variant="outline" size="lg" className="gap-2">
-                        <a href="https://github.com/Mayur-Pagote/README_Design_Kit/blob/main/README.md" target="_blank">
+                        <a href={`${siteConfig.githubUrl}/blob/main/README.md`} target="_blank" rel="noopener noreferrer">
                             <BookOpen className="w-4 h-4" /> View Documentation
                         </a>   
                     </Button>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,0 +1,9 @@
+// src/config/site.ts
+
+export const siteConfig = {
+  name: "README Design Kit",
+  // The main repository path used for fetching contributors
+  githubRepo: "Mayur-Pagote/README_Design_Kit",
+  // The full URL used for GitHub buttons and links
+  githubUrl: "https://github.com/Mayur-Pagote/README_Design_Kit",
+};


### PR DESCRIPTION
This pull request addresses the hardcoded repository path issue in the AboutUs component and introduces a UI enhancement to manage large lists of contributors more elegantly.

1. Dynamic Configuration:

- Created a central configuration file (src/config/site.ts) to store the primary GitHub repository path and URL.
- Replaced the hardcoded 'Code-writter/README_Design_Kit' string in the fetchContributors service call with the dynamic siteConfig.githubRepo variable.
- Updated all hardcoded GitHub repository URLs in the Hero, Footer, and CTA sections to use siteConfig.githubUrl. This ensures that if the repository is ever moved or forked, links won't break.

2. Pagination Enhancement:

- Implemented ShadCN UI Pagination for the "Our Amazing Contributors" grid.
- The grid now gracefully displays a maximum of 30 contributors per page (equivalent to 5 rows on desktop views), preventing the page from becoming infinitely long as the community grows.

Changes Made:

- Added: src/config/site.ts for centralized site constants.
- Modified: src/components/_components/about.tsx to integrate dynamic variables and internal pagination state (currentPage, ITEMS_PER_PAGE).
- Imported: Standard Pagination UI components (Pagination, PaginationContent, PaginationItem, etc.) to the about.tsx file.

Checklist:

- [x] Tested the fetchContributors logic to ensure data loads correctly.
- [x] Verified that clicking "Next", "Previous", and specific page numbers updates the grid properly.
- [x] Ensured all external GitHub links route correctly to the repo.
- [x] Code is properly formatted and free of warnings.

<img width="1920" height="4961" alt="image" src="https://github.com/user-attachments/assets/9167fc57-6c5a-4a1e-a1c1-b5788da68bcf" />

closes #595 


