### PR TITLE
feat: add terminal dashboard GitHub stats card

### DIFF
--- a/src/data/componentsData.ts
+++ b/src/data/componentsData.ts
@@ -115,6 +115,15 @@ export const componentsData: Record<string, ComponentItem[]> = {
         "![Stats Card 10](https://github-profile-summary-cards.vercel.app/api/cards/stats?username={username}&theme=2077)",
     },
     {
+      title: "Terminal Dashboard Card",
+      description:
+        "Terminal-inspired GitHub activity dashboard featuring commits, pull requests, issues, stars, contribution score, and contributor status.",
+      imageUrl:
+        "https://github-terminal-stats-card.vercel.app/api/card?username={username}",
+      codeSnippet:
+        "![Terminal Dashboard](https://github-terminal-stats-card.vercel.app/api/card?username={username})",
+    },
+    {
       title: "Stats Bar Card",
       description:
         "A horizontal bar-style GitHub widget showing followers, repositories, stars, and commits",


### PR DESCRIPTION
# 🛠 Pull Request Template

## 📌 Related Issue

Fixes: #623 

---

## 🔍 Describe your changes?

Added a new **Terminal Dashboard GitHub Stats Card** to the Stats collection.

The card provides a terminal-inspired developer dashboard that displays:

* Commits
* Pull Requests
* Issues
* Stars
* Contribution Score
* Active Contributor Status

The card is rendered dynamically through an external SVG endpoint and can be embedded directly into GitHub READMEs using a simple image URL.

The new card has been added to the `stats` component collection, allowing users to preview it alongside existing GitHub statistics cards and copy the corresponding markdown snippet.

---

## 📸 Screenshot

<!-- Insert screenshot of the Terminal Dashboard Card preview -->
<img width="1890" height="886" alt="image" src="https://github.com/user-attachments/assets/5196f335-d2ab-4ebf-999e-84c5d71f5f18" />


---

## 🧪 Checklist

* [x] I have tested my changes locally.
* [x] I have followed the project's code style and guidelines.
* [x] I have added necessary comments and documentation.
* [x] The code compiles and runs without errors.

---

## 🗒️ Additional Notes (Optional)

* Introduced a terminal-themed GitHub statistics card as an additional customization option.
* The card uses a dedicated SVG generator service and integrates seamlessly with the existing stats card collection.
* Supports dynamic username-based rendering.

---

## Thank you !

