### PR TITLE
feat: improve copy code button with animated success state

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "lucide-react": "^0.513.0",
     "microdiff": "^1.5.0",
     "monaco-editor": "^0.52.2",
-    "motion": "^12.18.1",
     "next-themes": "^0.4.6",
     "ogl": "^1.0.11",
     "react": "^19.1.0",

--- a/src/components/ComponentCard.tsx
+++ b/src/components/ComponentCard.tsx
@@ -1,5 +1,5 @@
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Copy, Check } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';

--- a/src/components/ComponentCard.tsx
+++ b/src/components/ComponentCard.tsx
@@ -1,6 +1,8 @@
 
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Copy } from 'lucide-react';
+import { Copy, Check } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 
 import { toast } from 'sonner';
 
@@ -14,11 +16,14 @@ interface ComponentCardProps {
 }
 
 export default function ComponentCard({ title, description, imageUrl, codeSnippet, username, repo }: ComponentCardProps) {
+  const [isCopied, setIsCopied] = useState(false);
 
   const handleCopyLink = async () => {
     try {
       const formattedCode = codeSnippet.replace(/\{username\}/g, username).replace(/\{repo\}/g, repo);
       await navigator.clipboard.writeText(formattedCode);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
       toast(
         `Copied to clipboard!, ${title} code has been copied to your clipboard.`,
       );
@@ -55,10 +60,42 @@ export default function ComponentCard({ title, description, imageUrl, codeSnippe
         <p className="text-sm text-gray-800 dark:text-gray-400 mb-4 flex-grow">{description}</p>
         <Button
           onClick={handleCopyLink}
-          className="w-full bg-primary hover:bg-primary/60 text-primary-foreground transform-gpu transition-transform duration-200 ease-out delay-75 hover:-translate-y-0.5 hover:scale-[1.03]"
+          className={`w-full text-primary-foreground transform-gpu transition-all duration-300 ease-out hover:-translate-y-0.5 hover:scale-[1.03] relative overflow-hidden ${
+            isCopied ? 'bg-green-500 hover:bg-green-600' : 'bg-primary hover:bg-primary/60'
+          }`}
         >
-          <Copy className="w-4 h-4 mr-2" />
-          Copy Code
+          <AnimatePresence mode="wait" initial={false}>
+            {isCopied ? (
+              <motion.div
+                key="copied"
+                initial={{ opacity: 0, y: 15 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -15 }}
+                transition={{ duration: 0.2 }}
+                className="flex items-center justify-center absolute inset-0"
+              >
+                <Check className="w-4 h-4 mr-2" />
+                Copied
+              </motion.div>
+            ) : (
+              <motion.div
+                key="copy"
+                initial={{ opacity: 0, y: 15 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -15 }}
+                transition={{ duration: 0.2 }}
+                className="flex items-center justify-center absolute inset-0"
+              >
+                <Copy className="w-4 h-4 mr-2" />
+                Copy Code
+              </motion.div>
+            )}
+          </AnimatePresence>
+          {/* Invisible placeholder to maintain button dimensions */}
+          <div className="flex items-center justify-center invisible">
+            <Copy className="w-4 h-4 mr-2" />
+            Copy Code
+          </div>
         </Button>
       </div>
     </div>

--- a/src/components/CustomComps/buttons/github-stars.tsx
+++ b/src/components/CustomComps/buttons/github-stars.tsx
@@ -14,7 +14,7 @@ import {
   type UseInViewOptions,
   easeInOut,
   easeOut,
-} from 'motion/react';
+} from 'framer-motion';
 
 import { cn } from '@/lib/utils';
 import { SlidingNumber } from '@/components/CustomComps/text/sliding-number';

--- a/src/components/CustomComps/text/sliding-number.tsx
+++ b/src/components/CustomComps/text/sliding-number.tsx
@@ -9,7 +9,7 @@ import {
   type MotionValue,
   type SpringOptions,
   type UseInViewOptions,
-} from 'motion/react';
+} from 'framer-motion';
 import useMeasure from 'react-use-measure';
 
 import { cn } from '@/lib/utils';

--- a/src/components/TemplateLibrary/TemplatePreview.tsx
+++ b/src/components/TemplateLibrary/TemplatePreview.tsx
@@ -4,13 +4,14 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Separator } from '@/components/ui/separator';
-import { Monitor, Smartphone, User, Calendar, Copy, Github, Rocket, Brain, FileCode, Settings2, Code2 } from 'lucide-react';
+import { Monitor, Smartphone, User, Calendar, Copy, Github, Rocket, Brain, FileCode, Settings2, Code2, Check } from 'lucide-react';
 import { useTheme } from '@/components/theme-provider';
 import { toast } from "sonner";
 import { generateMarkdown } from "@/utils/markdownGenerator";
 import { ElementRenderer } from '@/components/ElementRenderer';
 import { templateCategories } from '@/data/templates';
 import type { Template } from '@/types/templates';
+import { motion, AnimatePresence } from 'framer-motion';
 
 interface TemplatePreviewProps {
   template: Template;
@@ -24,6 +25,7 @@ export function TemplatePreview({ template }: TemplatePreviewProps) {
   const [projectTitle, setProjectTitle] = useState('Portfolio Dashboard'); 
   const [learningTech, setLearningTech] = useState('System Design');
   const [activeTab, setActiveTab] = useState('preview');
+  const [isCopied, setIsCopied] = useState(false);
 
   const { theme } = useTheme();
   const categoryLabel = templateCategories.find(c => c.value === template.category)?.label;
@@ -47,8 +49,10 @@ export function TemplatePreview({ template }: TemplatePreviewProps) {
       const contentToCopy = template.markdown 
         ? processedMarkdown 
         : generateMarkdown(template.elements || [], theme);
-
+      
       await navigator.clipboard.writeText(contentToCopy);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
       toast.success("Markdown copied to clipboard");
     } catch (err) {
       toast.error("Failed to copy markdown");
@@ -148,11 +152,42 @@ export function TemplatePreview({ template }: TemplatePreviewProps) {
         <div className="flex flex-col gap-3 mt-auto pb-4 lg:pb-0">
           <Button 
             onClick={handleCopyMarkdown} 
-            className="w-full font-semibold h-11 shadow-lg shadow-primary/20 hover:scale-100 cursor-pointer" 
+            className={`w-full font-semibold h-11 shadow-lg shadow-primary/20 cursor-pointer relative overflow-hidden transition-all duration-300 ${
+              isCopied ? 'bg-green-500 hover:bg-green-600 text-white' : ''
+            }`} 
             size="lg"
           >
-            <Copy className="h-4 w-4 mr-2" />
-            Copy Markdown Code
+            <AnimatePresence mode="wait" initial={false}>
+              {isCopied ? (
+                <motion.div
+                  key="copied"
+                  initial={{ opacity: 0, y: 15 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -15 }}
+                  transition={{ duration: 0.2 }}
+                  className="flex items-center justify-center absolute inset-0"
+                >
+                  <Check className="h-4 w-4 mr-2" />
+                  Copied
+                </motion.div>
+              ) : (
+                <motion.div
+                  key="copy"
+                  initial={{ opacity: 0, y: 15 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -15 }}
+                  transition={{ duration: 0.2 }}
+                  className="flex items-center justify-center absolute inset-0"
+                >
+                  <Copy className="h-4 w-4 mr-2" />
+                  Copy Markdown Code
+                </motion.div>
+              )}
+            </AnimatePresence>
+            <div className="flex items-center justify-center invisible">
+              <Copy className="h-4 w-4 mr-2" />
+              Copy Markdown Code
+            </div>
           </Button>
         </div>
       </div>
@@ -197,8 +232,40 @@ export function TemplatePreview({ template }: TemplatePreviewProps) {
             )}
             
             {activeTab === 'markdown' && (
-               <Button size="sm" variant="ghost" className="h-8 text-xs" onClick={handleCopyMarkdown}>
-                  <Copy className="h-3.5 w-3.5 mr-2" /> Copy Code
+               <Button 
+                 size="sm" 
+                 variant="ghost" 
+                 className={`h-8 text-xs relative overflow-hidden transition-all duration-300 ${isCopied ? 'text-green-500 hover:text-green-600' : ''}`} 
+                 onClick={handleCopyMarkdown}
+               >
+                  <AnimatePresence mode="wait" initial={false}>
+                    {isCopied ? (
+                      <motion.div
+                        key="copied"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        transition={{ duration: 0.2 }}
+                        className="flex items-center justify-center absolute inset-0"
+                      >
+                        <Check className="h-3.5 w-3.5 mr-2" /> Copied
+                      </motion.div>
+                    ) : (
+                      <motion.div
+                        key="copy"
+                        initial={{ opacity: 0, y: 10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={{ opacity: 0, y: -10 }}
+                        transition={{ duration: 0.2 }}
+                        className="flex items-center justify-center absolute inset-0"
+                      >
+                        <Copy className="h-3.5 w-3.5 mr-2" /> Copy Code
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                  <div className="flex items-center justify-center invisible">
+                    <Copy className="h-3.5 w-3.5 mr-2" /> Copy Code
+                  </div>
                </Button>
             )}
           </div>

--- a/src/components/_components/backgroundlines.tsx
+++ b/src/components/_components/backgroundlines.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@/lib/utils";
-import { motion } from "motion/react";
+import { motion } from "framer-motion";
 import React from "react";
 
 export const BackgroundLines = ({

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -151,7 +151,7 @@ function Calendar({
           )
         },
         DayButton: CalendarDayButton,
-        WeekNumber: ({ children, ...props }) => {
+        WeekNumber: ({ children, ...props }: React.HTMLProps<HTMLTableCellElement>) => {
           return (
             <td {...props}>
               <div className="flex size-(--cell-size) items-center justify-center text-center">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowRight, Layout } from 'lucide-react'; // Removed Bot icon import
 import { QuickStartGuide } from '@/components/QuickStartGuide';
 
-import { motion } from "motion/react";
+import { motion } from "framer-motion";
 import Aurora from "@/components/LandingComponents/Aurora";
 import LiquidChrome from "@/components/LandingComponents/LiquidChrome";
 import { useTheme } from "@/components/theme-provider";


### PR DESCRIPTION
### Description
Currently, when a user clicks the **Copy Code** button on the README design cards or template preview, only a toast notification is shown. This PR introduces a smooth, direct visual feedback animation on the button itself to make the interface feel more intuitive, responsive, and modern.

### Changes Made
* Added local `isCopied` state to the `ComponentCard` and `TemplatePreview` components.
* Updated the **Copy Code** buttons to dynamically change their text to **Copied** and swap the icon to a Check/Tick (`<Check />`).
* Added smooth, sliding pop-in/pop-out transitions between states using `framer-motion` (`<AnimatePresence>`).
* Added a temporary success color (`bg-green-500`) to the button when clicked.
* Maintained the original toast notification as secondary feedback.
* Refactored several components importing from `motion/react` to use `framer-motion` instead, fixing a dependency resolution issue and removing the unused `motion` dependency.

### Visual Proof
_Please check the screen recording below to see the animated success states in action!_


https://github.com/user-attachments/assets/054e463c-91a5-4787-af7c-eff88c66b907



### Related Issue
Fixes #624 

### Checklist
- [x] Tested the changes locally.
- [x] Code follows the project's structure and coding style.
- [x] Ensured animations are smooth and do not cause layout shifts.

