### PR TITLE
feat: add README theme packs (curated component bundles) (#643)

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,15 @@ Detailed documentation of every file and directory in the project, explaining th
 - Configuration files
 - Asset organization
 
+### 🎨 [Theme Packs](./theme-packs.md)
+Curated bundles of matching banners, badges, and dividers that share one visual language.
+
+**Topics Covered:**
+- The available packs (Neon, Minimal, Retro)
+- Using and copying packs
+- Mixing packs without breaking consistency
+- Authoring and extending your own pack
+
 ## 🔗 Additional Resources
 
 ### 🎨 [README Elements Library](../READMEelements.md)

--- a/docs/theme-packs.md
+++ b/docs/theme-packs.md
@@ -1,0 +1,95 @@
+# 🎨 Theme Packs
+
+**Theme packs** are curated, coordinated bundles of README components — a matching
+**banner**, **badges**, and **divider** that all share one visual language. Instead of
+hand-picking individual elements (and ending up with a README where every section looks
+like it came from a different project), you grab a pack and get a consistent look in one
+copy.
+
+Browse them in the app at **[`/theme-packs`](https://github.com/Mayur-Pagote/README_Design_Kit)**
+(navigate via **More → Theme Packs**).
+
+## 📦 What ships today
+
+| Pack | Vibe | Palette |
+| --- | --- | --- |
+| **Neon** | High-contrast cyberpunk — animated, glowing accents | Magenta · Cyan · Violet |
+| **Minimal** | Clean, monochrome, distraction-free | Slate · Gray · Light gray |
+| **Retro** | Warm vintage arcade energy | Sunset orange · Amber · Cream |
+
+Each pack includes:
+
+- **Banner** — a header image (via [capsule-render](https://github.com/kyechan99/capsule-render)).
+- **Badges** — a coordinated set of [Shields.io](https://shields.io) badges.
+- **Divider** — a matching section separator.
+
+## 🚀 Using a pack
+
+1. Open the **Theme Packs** page.
+2. (Optional) Enter your GitHub **username** and **repo** at the top — every snippet and
+   preview updates live with your values.
+3. Either:
+   - **Copy full pack** — grabs the banner, badges, and divider as one ready-to-paste
+     Markdown block, or
+   - **Copy** a single component if you only want one piece.
+4. Paste into your `README.md`.
+
+The "Copy full pack" output looks like this (Neon example):
+
+```markdown
+<!-- Neon Theme Pack — via README Design Kit -->
+<img src="https://capsule-render.vercel.app/api?type=waving&color=0:FF00FF,100:00FFFF&height=200&section=header&text=your-repo&..." width="100%" />
+
+![Built with Love](https://img.shields.io/badge/Built_with-Love-FF00FF?style=flat-square&labelColor=1a1a2e)
+![Stars](https://img.shields.io/github/stars/your-username/your-repo?style=flat-square&color=00FFFF&labelColor=1a1a2e)
+![License](https://img.shields.io/badge/License-MIT-8A2BE2?style=flat-square&labelColor=1a1a2e)
+
+<img src="https://github.com/.../RGB%20Line%20Thick.gif?raw=true" width="100%" />
+```
+
+## 🧩 Mixing packs
+
+Packs are a starting point, not a cage. A few rules of thumb to keep things coherent:
+
+- **Match palettes, not packs.** You can pull a banner from one pack and badges from
+  another as long as the colors agree. Each pack lists its accent colors (the hex chips
+  next to its name) — reuse those hex values anywhere you add custom elements.
+- **Keep one badge style.** Shields supports `flat`, `flat-square`, `plastic`, and
+  `for-the-badge`. Stick to a single style across your README — Neon uses `flat-square`,
+  Minimal uses `flat`, Retro uses `plastic`.
+- **One divider, used consistently.** Reuse the same divider between every section rather
+  than alternating styles.
+
+## 🛠️ Extending: author your own pack
+
+Packs live in [`src/data/themePacks.ts`](../src/data/themePacks.ts). Add a new object to
+the `themePacks` array:
+
+```ts
+{
+  id: "ocean",                 // unique, used for keys + #anchor
+  name: "Ocean",
+  description: "Cool blues and teal with a calm, flowing feel.",
+  colors: ["0077B6", "00B4D8", "90E0EF"], // hex without '#'
+  components: {
+    banner:  { title: "Banner",  description: "...", imageUrl: "...", codeSnippet: "..." },
+    badges:  { title: "Badges",  description: "...", imageUrl: "...", codeSnippet: "..." },
+    divider: { title: "Divider", description: "...", imageUrl: "...", codeSnippet: "..." },
+  },
+}
+```
+
+Notes:
+
+- `imageUrl` is the live preview shown in the gallery; `codeSnippet` is what gets copied.
+  They can differ (e.g. a static preview for an animated snippet).
+- Use the `{username}` and `{repo}` placeholders anywhere — they're substituted with the
+  visitor's input at copy time (and fall back to `your-username` / `your-repo`).
+- Keep all three components in the **same palette** so the pack reads as a set.
+- That's it — the gallery page, quick-jump links, and "Copy full pack" button pick up new
+  packs automatically. No page changes required.
+
+---
+
+*Part of the [README Design Kit](../README.md) documentation. See the
+[Documentation Index](./INDEX.md) for more guides.*

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Home from "./pages/Home";
 import Layout from "./components/Layout";
 import ScrollRestoration from "./components/ScrollRestoration";
 import Elements from "./pages/Elements";
+import ThemePacks from "./pages/ThemePacks";
 
 import DragDropEditor from "./pages/DragDropEditor";
 import TemplateLibraryPage from "./pages/TemplateLibraryPage";
@@ -55,6 +56,7 @@ export default function App() {
 
                 <Route path="/" element={<Layout><Home /></Layout>} />
                 <Route path="/elements" element={<Layout><Elements /></Layout>} />
+                <Route path="/theme-packs" element={<Layout><ThemePacks /></Layout>} />
                 <Route path="/templates" element={<Layout><TemplateLibraryPage /></Layout>} />
                 <Route path="/projects" element={<Layout><ProjectsSection /></Layout>} />
                 <Route path="/submit" element={<Layout><SubmitSection /></Layout>} />

--- a/src/components/ThemePackCard.tsx
+++ b/src/components/ThemePackCard.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Copy, Check, Layers } from "lucide-react";
+import { toast } from "sonner";
+import {
+  buildPackMarkdown,
+  type ThemePack,
+  type ThemePackComponent,
+} from "@/data/themePacks";
+
+interface ThemePackCardProps {
+  pack: ThemePack;
+  username: string;
+  repo: string;
+}
+
+function format(text: string, username: string, repo: string) {
+  return text
+    .replace(/\{username\}/g, username || "your-username")
+    .replace(/\{repo\}/g, repo || "your-repo");
+}
+
+function CopyButton({
+  label,
+  getText,
+  fullWidth = false,
+}: {
+  label: string;
+  getText: () => string;
+  fullWidth?: boolean;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(getText());
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+      toast(`Copied! ${label} added to your clipboard.`);
+    } catch (err) {
+      console.error("Failed to copy to clipboard:", err);
+      toast("Failed to copy, please try again.");
+    }
+  };
+
+  return (
+    <Button
+      size="sm"
+      onClick={handleCopy}
+      variant={copied ? "default" : "secondary"}
+      className={`${fullWidth ? "w-full" : ""} ${
+        copied ? "bg-green-500 hover:bg-green-600 text-white" : ""
+      }`}
+    >
+      {copied ? (
+        <>
+          <Check className="w-4 h-4 mr-2" /> Copied
+        </>
+      ) : (
+        <>
+          <Copy className="w-4 h-4 mr-2" /> {label}
+        </>
+      )}
+    </Button>
+  );
+}
+
+function ComponentRow({
+  component,
+  username,
+  repo,
+}: {
+  component: ThemePackComponent;
+  username: string;
+  repo: string;
+}) {
+  return (
+    <div className="rounded-xl border border-border bg-muted/30 p-4 flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h4 className="font-semibold text-foreground">{component.title}</h4>
+          <p className="text-sm text-muted-foreground">{component.description}</p>
+        </div>
+        <CopyButton
+          label="Copy"
+          getText={() => format(component.codeSnippet, username, repo)}
+        />
+      </div>
+      <div className="rounded-lg bg-background border border-border p-3 flex items-center justify-center overflow-hidden">
+        <img
+          src={format(component.imageUrl, username, repo)}
+          alt={component.title}
+          className="max-w-full max-h-32 object-contain"
+          loading="lazy"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function ThemePackCard({
+  pack,
+  username,
+  repo,
+}: ThemePackCardProps) {
+  const { banner, badges, divider } = pack.components;
+
+  return (
+    <section
+      id={pack.id}
+      className="rounded-2xl border border-border bg-card shadow-sm overflow-hidden"
+    >
+      {/* Accent strip from the pack's palette */}
+      <div
+        className="h-1.5 w-full"
+        style={{
+          background: `linear-gradient(90deg, ${pack.colors
+            .map((c) => `#${c}`)
+            .join(", ")})`,
+        }}
+      />
+
+      <div className="p-6 flex flex-col gap-5">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="flex-1 min-w-[220px]">
+            <div className="flex items-center gap-3 mb-2">
+              <h2 className="text-2xl font-bold text-foreground">{pack.name}</h2>
+              <div className="flex gap-1">
+                {pack.colors.map((c) => (
+                  <span
+                    key={c}
+                    className="h-4 w-4 rounded-full border border-border"
+                    style={{ backgroundColor: `#${c}` }}
+                    title={`#${c}`}
+                  />
+                ))}
+              </div>
+            </div>
+            <p className="text-muted-foreground max-w-2xl">{pack.description}</p>
+          </div>
+
+          <CopyButton
+            label="Copy full pack"
+            getText={() => buildPackMarkdown(pack, username, repo)}
+          />
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+          <ComponentRow component={banner} username={username} repo={repo} />
+          <ComponentRow component={badges} username={username} repo={repo} />
+          <ComponentRow component={divider} username={username} repo={repo} />
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <Layers className="w-4 h-4" />
+          Copy each piece individually, or grab the whole coordinated set with
+          &ldquo;Copy full pack&rdquo;.
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/_components/header.tsx
+++ b/src/components/_components/header.tsx
@@ -15,10 +15,11 @@ import {
 
 
 const moreItems = [
+  { name: 'Theme Packs', to: '/theme-packs' },
   { name: 'Templates', to: '/templates' },
   { name: 'Drag & Drop Editor', to: '/drag-drop' },
   { name: 'Readme Generator', to: '/readme-generator' },
-  
+
 ]
 
 export const Header = () => {
@@ -181,6 +182,7 @@ export const Header = () => {
             <div className="lg:hidden pb-4 mt-4 space-y-2 border-t border-white/10 animate-in fade-in slide-in-from-top-2 bg-background/95 backdrop-blur-md rounded-xl">
               {[
                 { name: "Elements", to: "/elements" },
+                { name: "Theme Packs", to: "/theme-packs" },
                 { name: "Templates", to: "/templates" },
                 { name: "Drag & Drop Editor", to: "/drag-drop" },
                 { name: "Readme Generator", to: "/readme-generator" },

--- a/src/data/themePacks.ts
+++ b/src/data/themePacks.ts
@@ -1,0 +1,169 @@
+// Theme Packs — curated, coordinated bundles of README components (banner, badges,
+// and divider) that share a single visual language. Pick a pack and copy a whole set
+// of matching elements instead of stitching together mismatched components.
+//
+// See `docs/theme-packs.md` for guidance on mixing and extending packs.
+
+export interface ThemePackComponent {
+  /** Short label for the component (e.g. "Banner", "Badges", "Divider"). */
+  title: string;
+  /** One-line description of what the component is. */
+  description: string;
+  /** Preview image rendered in the gallery. Supports {username} / {repo} placeholders. */
+  imageUrl: string;
+  /** Ready-to-copy Markdown / HTML snippet. Supports {username} / {repo} placeholders. */
+  codeSnippet: string;
+}
+
+export interface ThemePack {
+  /** Unique id used for keys and anchors. */
+  id: string;
+  /** Display name of the pack (e.g. "Neon"). */
+  name: string;
+  /** One-line summary of the pack's aesthetic. */
+  description: string;
+  /** Representative accent colors (hex, no `#`) used for the gallery accent + chips. */
+  colors: string[];
+  /** The matching components that make up the pack. */
+  components: {
+    banner: ThemePackComponent;
+    badges: ThemePackComponent;
+    divider: ThemePackComponent;
+  };
+}
+
+export const themePacks: ThemePack[] = [
+  {
+    id: "neon",
+    name: "Neon",
+    description:
+      "High-contrast cyberpunk vibes — electric magenta and cyan on a dark canvas with animated, glowing accents.",
+    colors: ["FF00FF", "00FFFF", "8A2BE2"],
+    components: {
+      banner: {
+        title: "Banner",
+        description: "Waving gradient header with a neon magenta-to-cyan glow.",
+        imageUrl:
+          "https://capsule-render.vercel.app/api?type=waving&color=0:FF00FF,100:00FFFF&height=200&section=header&text={repo}&fontColor=ffffff&fontSize=55&fontAlignY=38&desc=Crafted%20with%20Neon&descAlignY=58&animation=fadeIn",
+        codeSnippet:
+          '<img src="https://capsule-render.vercel.app/api?type=waving&color=0:FF00FF,100:00FFFF&height=200&section=header&text={repo}&fontColor=ffffff&fontSize=55&fontAlignY=38&desc=Crafted%20with%20Neon&descAlignY=58&animation=fadeIn" width="100%" />',
+      },
+      badges: {
+        title: "Badges",
+        description: "Flat-square badges in neon magenta and cyan.",
+        imageUrl:
+          "https://img.shields.io/badge/Built_with-Love-FF00FF?style=flat-square&labelColor=1a1a2e",
+        codeSnippet: [
+          "![Built with Love](https://img.shields.io/badge/Built_with-Love-FF00FF?style=flat-square&labelColor=1a1a2e)",
+          "![Stars](https://img.shields.io/github/stars/{username}/{repo}?style=flat-square&color=00FFFF&labelColor=1a1a2e)",
+          "![License](https://img.shields.io/badge/License-MIT-8A2BE2?style=flat-square&labelColor=1a1a2e)",
+        ].join("\n"),
+      },
+      divider: {
+        title: "Divider",
+        description: "Animated RGB line that matches the neon glow.",
+        imageUrl:
+          "https://github.com/Mayur-Pagote/README_Design_Kit/blob/730d340c8008758ac291ebc555f818f851feda0f/Assets/RGB%20Line%20Thick.gif?raw=true",
+        codeSnippet:
+          '<img src="https://github.com/Mayur-Pagote/README_Design_Kit/blob/730d340c8008758ac291ebc555f818f851feda0f/Assets/RGB%20Line%20Thick.gif?raw=true" width="100%" />',
+      },
+    },
+  },
+  {
+    id: "minimal",
+    name: "Minimal",
+    description:
+      "Clean, monochrome, and distraction-free — soft grays, flat badges, and a subtle hairline divider for a professional look.",
+    colors: ["1f2937", "6b7280", "d1d5db"],
+    components: {
+      banner: {
+        title: "Banner",
+        description: "Simple flat header in muted slate with centered title.",
+        imageUrl:
+          "https://capsule-render.vercel.app/api?type=rect&color=1f2937&height=160&section=header&text={repo}&fontColor=ffffff&fontSize=48&fontAlignY=50&desc=Minimal%20%C2%B7%20Clean%20%C2%B7%20Focused&descAlignY=72&descSize=16",
+        codeSnippet:
+          '<img src="https://capsule-render.vercel.app/api?type=rect&color=1f2937&height=160&section=header&text={repo}&fontColor=ffffff&fontSize=48&fontAlignY=50&desc=Minimal%20%C2%B7%20Clean%20%C2%B7%20Focused&descAlignY=72&descSize=16" width="100%" />',
+      },
+      badges: {
+        title: "Badges",
+        description: "Flat grayscale badges with no logos for a restrained look.",
+        imageUrl:
+          "https://img.shields.io/badge/status-active-6b7280?style=flat&labelColor=1f2937",
+        codeSnippet: [
+          "![Status](https://img.shields.io/badge/status-active-6b7280?style=flat&labelColor=1f2937)",
+          "![Stars](https://img.shields.io/github/stars/{username}/{repo}?style=flat&color=6b7280&labelColor=1f2937)",
+          "![License](https://img.shields.io/badge/license-MIT-d1d5db?style=flat&labelColor=1f2937)",
+        ].join("\n"),
+      },
+      divider: {
+        title: "Divider",
+        description: "A thin, static multicolor-free hairline to separate sections.",
+        imageUrl:
+          "https://capsule-render.vercel.app/api?type=rect&color=d1d5db&height=2&section=header",
+        codeSnippet:
+          '<img src="https://capsule-render.vercel.app/api?type=rect&color=d1d5db&height=2&section=header" width="100%" />',
+      },
+    },
+  },
+  {
+    id: "retro",
+    name: "Retro",
+    description:
+      "Warm vintage arcade energy — sunset oranges and creams with a chunky pixel-friendly header and a classic divider.",
+    colors: ["FF6F3C", "F4A259", "FFE6A7"],
+    components: {
+      banner: {
+        title: "Banner",
+        description: "Retro sunset gradient header with a bold display font.",
+        imageUrl:
+          "https://capsule-render.vercel.app/api?type=slice&color=0:FF6F3C,100:F4A259&height=200&section=header&text={repo}&fontColor=2b2118&fontSize=52&fontAlignY=60&desc=Insert%20Coin%20to%20Continue&descAlignY=80&descSize=16&rotate=13",
+        codeSnippet:
+          '<img src="https://capsule-render.vercel.app/api?type=slice&color=0:FF6F3C,100:F4A259&height=200&section=header&text={repo}&fontColor=2b2118&fontSize=52&fontAlignY=60&desc=Insert%20Coin%20to%20Continue&descAlignY=80&descSize=16&rotate=13" width="100%" />',
+      },
+      badges: {
+        title: "Badges",
+        description: "Plastic-style badges in warm retro oranges and cream.",
+        imageUrl:
+          "https://img.shields.io/badge/made_with-pixels-FF6F3C?style=plastic&labelColor=2b2118",
+        codeSnippet: [
+          "![Made with Pixels](https://img.shields.io/badge/made_with-pixels-FF6F3C?style=plastic&labelColor=2b2118)",
+          "![Stars](https://img.shields.io/github/stars/{username}/{repo}?style=plastic&color=F4A259&labelColor=2b2118)",
+          "![License](https://img.shields.io/badge/license-MIT-FFE6A7?style=plastic&labelColor=2b2118)",
+        ].join("\n"),
+      },
+      divider: {
+        title: "Divider",
+        description: "A warm fading line that complements the retro palette.",
+        imageUrl:
+          "https://user-images.githubusercontent.com/74038190/212284100-561aa473-3905-4a80-b561-0d28506553ee.gif",
+        codeSnippet:
+          '<img src="https://user-images.githubusercontent.com/74038190/212284100-561aa473-3905-4a80-b561-0d28506553ee.gif" width="100%" />',
+      },
+    },
+  },
+];
+
+/**
+ * Build a single ready-to-paste Markdown block for an entire pack
+ * (banner → badges → divider), with placeholders substituted.
+ */
+export function buildPackMarkdown(
+  pack: ThemePack,
+  username: string,
+  repo: string
+): string {
+  const { banner, badges, divider } = pack.components;
+  const block = [
+    `<!-- ${pack.name} Theme Pack — via README Design Kit -->`,
+    banner.codeSnippet,
+    "",
+    badges.codeSnippet,
+    "",
+    divider.codeSnippet,
+    "",
+  ].join("\n");
+
+  return block
+    .replace(/\{username\}/g, username || "your-username")
+    .replace(/\{repo\}/g, repo || "your-repo");
+}

--- a/src/pages/ThemePacks.tsx
+++ b/src/pages/ThemePacks.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import UserInput from "@/components/UserInput";
+import ThemePackCard from "@/components/ThemePackCard";
+import { themePacks } from "@/data/themePacks";
+
+export default function ThemePacks() {
+  const [username, setUsername] = useState("Mayur-Pagote");
+  const [repo, setRepo] = useState("README_Design_Kit");
+
+  return (
+    <div className="min-h-screen bg-background">
+      {/* Page Header */}
+      <div className="border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="container mx-auto px-6 py-8">
+          <div className="text-center">
+            <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+              Theme Packs
+            </h1>
+            <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
+              Curated bundles of matching banners, badges, and dividers that share
+              one visual language. Pick a pack and copy a coordinated set instead of
+              stitching together mismatched components.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <UserInput
+        onUsernameChange={(u) => setUsername(u)}
+        onRepoChange={(r) => setRepo(r)}
+        defaultUsername="Mayur-Pagote"
+        defaultRepo="README_Design_Kit"
+      />
+
+      {/* Quick jump */}
+      <div className="container mx-auto px-6 pt-4">
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          <span className="text-sm text-muted-foreground">Jump to:</span>
+          {themePacks.map((pack) => (
+            <a
+              key={pack.id}
+              href={`#${pack.id}`}
+              className="text-sm px-3 py-1 rounded-full border border-border hover:bg-accent/40 transition-colors"
+            >
+              {pack.name}
+            </a>
+          ))}
+        </div>
+      </div>
+
+      {/* Gallery */}
+      <div className="container mx-auto px-6 py-8 flex flex-col gap-8">
+        {themePacks.map((pack) => (
+          <ThemePackCard
+            key={pack.id}
+            pack={pack}
+            username={username}
+            repo={repo}
+          />
+        ))}
+      </div>
+
+      {/* Mix & extend note */}
+      <div className="container mx-auto px-6 pb-12">
+        <div className="rounded-2xl border border-border bg-muted/30 p-6 max-w-3xl mx-auto">
+          <h3 className="font-semibold text-foreground mb-2">
+            Mixing &amp; extending packs
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            Packs are a starting point, not a cage. Keep a consistent look by reusing
+            one pack&apos;s accent colors across any extra components you add, or mix a
+            banner from one pack with badges from another as long as the palettes
+            agree. Full guidance — including how to author your own pack — lives in{" "}
+            <code className="text-foreground">docs/theme-packs.md</code>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
##  Overview

Adds **Theme Packs** — curated, coordinated bundles of README components where the
**banner**, **badges**, and **divider** all share one visual language. Instead of
picking individual elements that end up clashing, users grab a pack and get a
consistent look in a single copy.

Three packs ship in this PR: **Neon**, **Minimal**, and **Retro**.

##  Acceptance criteria

| Requirement | Status | Where |
| --- | :---: | --- |
| At least 3 initial theme packs | ✅ | `src/data/themePacks.ts` (Neon, Minimal, Retro) |
| Each pack has a matching badge, banner & divider | ✅ | `src/data/themePacks.ts` |
| Gallery / showcase page for browsing packs | ✅ | `src/pages/ThemePacks.tsx` → route `/theme-packs` |
| Ready-to-copy Markdown snippets per pack | ✅ | `src/components/ThemePackCard.tsx` ("Copy" + "Copy full pack") |
| Documentation on mixing & extending packs | ✅ | `docs/theme-packs.md` + `docs/INDEX.md` |

##  What's included

- **`src/data/themePacks.ts`** — typed pack data (`ThemePack`, `ThemePackComponent`)
  plus a `buildPackMarkdown()` helper that assembles a full pack into one paste-ready
  Markdown block.
- **`src/pages/ThemePacks.tsx`** — gallery page with:
  - live **username / repo** inputs (every preview and snippet updates instantly),
  - **quick-jump** links to each pack,
  - a **mixing & extending** note.
- **`src/components/ThemePackCard.tsx`** — per-pack card showing live previews of the
  banner, badges, and divider, with **per-component copy** and a **"Copy full pack"**
  button. Supports `{username}` / `{repo}` placeholder substitution.
- **Routing & nav** — `/theme-packs` route in `App.tsx`, plus links in the desktop
  **More** dropdown and the mobile menu (`header.tsx`).
- **Docs** — `docs/theme-packs.md` (usage, mixing rules, and how to author your own
  pack) and an entry in `docs/INDEX.md`.

##  The packs

| Pack | Vibe | Palette |
| --- | --- | --- |
| **Neon** | High-contrast cyberpunk with animated, glowing accents | Magenta · Cyan · Violet |
| **Minimal** | Clean, monochrome, distraction-free | Slate · Gray · Light gray |
| **Retro** | Warm vintage arcade energy | Sunset orange · Amber · Cream |

Each uses well-supported services already used elsewhere in the project:
[capsule-render](https://github.com/kyechan99/capsule-render) for banners,
[Shields.io](https://shields.io) for badges, and the existing repo divider assets.

##  Testing

- `tsc` typecheck — **clean**
- `npm run build` (production Vite build) — **passes** (all modules transformed)
- `/theme-packs` route serves **200**
- All snippet image URLs verified reachable (capsule-render, Shields.io, divider GIF)
- Verified responsive layout (desktop grid + mobile stacking) and copy buttons

##  How to try it

1. `npm install && npm run dev`
2. Navigate to **More → Theme Packs** (or visit `/theme-packs`)
3. Enter your GitHub username/repo, then **Copy full pack** and paste into a README

Close #643 