### PR TITLE
chore: Optimize vendor chunk size via Vite manualChunks

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,7 +16,12 @@ export default defineConfig({
       output: {
         manualChunks(id) {
           if (id.includes("node_modules")) {
-            return "vendor"; // ✅ Splits heavy dependencies into a separate chunk
+            const split = id.toString().split("node_modules/");
+            const pathAfterNodeModules = split[split.length - 1];
+            const packageName = pathAfterNodeModules.split("/")[0].startsWith("@")
+              ? pathAfterNodeModules.split("/")[0] + "/" + pathAfterNodeModules.split("/")[1]
+              : pathAfterNodeModules.split("/")[0];
+            return packageName;
           }
         },
       },


### PR DESCRIPTION
Resolves #656

### Description
This PR resolves the `Some chunks are larger than 800 kB` warning produced during the Vite production build by optimizing how third-party dependencies are bundled. 

Previously, all `node_modules` were lumped into a single massive `vendor` chunk (which exceeded 2MB), significantly impacting the initial load performance of the application. 

### Changes Made
- Updated `manualChunks` in `vite.config.ts` to explicitly split all dependencies inside `node_modules` into their own separate chunks, based on their package names.
- This successfully eliminates the chunk size warning and ensures the browser only downloads the smaller, relevant dependencies as they are needed.
- Note: `React.lazy()` and `Suspense` were already implemented effectively for routing within `src/App.tsx`, so no further dynamic imports were necessary.

### Verification
- `npm run build` succeeds perfectly with well-distributed chunk sizes.
- `npm run validate:components` passes.
- All code changes are minimal and strictly targeted at resolving the Vite chunking issue.
